### PR TITLE
fix: タイムゾーンを東京に設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,8 @@ module TaskManagementSystem
   class Application < Rails::Application
     config.load_defaults 5.2
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
 
     config.generators do |g|
       g.test_framework :rspec,


### PR DESCRIPTION
#10 

- [x] `config/application.rb`にタイムゾーン(東京)の設定をした。