### PR TITLE
add: Taskテーブルのsubject及びcontentカラムにNotNull制約とバリデーション追加。及びテスト作成

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,7 @@
 class Task < ApplicationRecord
+  validates :subject, presence: true
+  validates :content, presence: true
+
   def self.latest
     order(created_at: :desc)
   end

--- a/db/migrate/20190618073545_change_column_null_tasks.rb
+++ b/db/migrate/20190618073545_change_column_null_tasks.rb
@@ -1,0 +1,6 @@
+class ChangeColumnNullTasks < ActiveRecord::Migration[5.2]
+  def change
+    change_column :tasks, :subject, :string, null: false
+    change_column :tasks, :content, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_14_054215) do
+ActiveRecord::Schema.define(version: 2019_06_18_073545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "tasks", force: :cascade do |t|
-    t.string "subject"
-    t.string "content"
+    t.string "subject", null: false
+    t.string "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  it 'subjectの値がnilでNotNull制約違反になる' do
+    task = Task.new(subject: nil, content: '失敗テスト')
+    expect(task).not_to be_valid
+  end
+
+  it 'contentの値がnilでNotNull制約違反になる' do
+    task = Task.new(subject: '失敗テスト', content: nil)
+    expect(task).not_to be_valid
+  end
+
+  it 'subjectが空ならバリデーションが通らない' do
+    task = Task.new(subject:'', content: '失敗テスト')
+    expect(task).not_to be_valid
+  end
+
+  it 'contentが空ならバリデーションが通らない' do
+    task = Task.new(subject:'失敗テスト', content: '')
+    expect(task).not_to be_valid
+  end
+
+  it 'subjectとcontentに内容が記載されていればバリデーションが通る' do
+    task = Task.new(subject: '成功テスト', content: '成功テスト')
+    expect(task).to be_valid
+  end
+end


### PR DESCRIPTION
#14 

- [x] tasksテーブルのsubjectカラムとcontentカラムにNot Null制約を付与。
- [x] tasksテーブルのsubjectカラムとcontentカラムに空白入力禁止のバリデーション設定。
- [x] Not Null制約と空白入力禁止のバリデーションのテストを作成。

バリデーションのエラーメッセージ出力処理はすでに作成済みでした。下記リンクをご参照下さい。
https://github.com/noriya1217/task_management_system/blob/master/app/views/tasks/_form.html.erb