### PR TITLE
ステータスを追加して、検索できるようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'devise'
   gem 'factory_bot_rails'
+  gem 'faker'
   gem 'launchy'
   gem 'pry-rails'
   gem 'rspec-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,11 @@ ruby '2.6.3'
 
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'coffee-rails', '~> 4.2'
+gem 'enum_help'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.11'
 gem 'rails', '~> 5.2.3'
+gem 'ransack'
 gem 'sass-rails', '~> 5.0'
 gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
     factory_bot_rails (5.0.2)
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
+    faker (1.9.3)
+      i18n (>= 0.7)
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -291,6 +293,7 @@ DEPENDENCIES
   devise
   enum_help
   factory_bot_rails
+  faker
   launchy
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.8.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -181,6 +183,11 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (12.3.2)
+    ransack (2.1.1)
+      actionpack (>= 5.0)
+      activerecord (>= 5.0)
+      activesupport (>= 5.0)
+      i18n
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -282,6 +289,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   database_cleaner
   devise
+  enum_help
   factory_bot_rails
   launchy
   listen (>= 3.0.5, < 3.2)
@@ -290,6 +298,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.3)
   rails_best_practices
+  ransack
   rspec-rails
   rubocop
   sass-rails (~> 5.0)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -14,7 +14,6 @@ class TasksController < ApplicationController
       params[:q] = nil if params[:q][:subject_cont].blank?
     end
 
-    binding.pry
     @q = Task.search_ransack(params[:q])
     @searchs = @q.result(distinct: true)
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -8,15 +8,15 @@ class TasksController < ApplicationController
       @tasks = Task.latest
     end
     if params[:q].nil?
-      
-    elsif params[:q][:state_cont] == '指定無し'
-      params[:q][:state_cont] = nil
+
+    elsif params[:q][:state_eq] == '指定無し'
+      params[:q][:state_eq] = nil
       params[:q] = nil if params[:q][:subject_cont].blank?
     end
 
-    @q = Task.ransack(params[:q])
+    binding.pry
+    @q = Task.search_ransack(params[:q])
     @searchs = @q.result(distinct: true)
-    # binding.pry
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,6 +7,16 @@ class TasksController < ApplicationController
     else
       @tasks = Task.latest
     end
+    if params[:q].nil?
+      
+    elsif params[:q][:state_cont] == '指定無し'
+      params[:q][:state_cont] = nil
+      params[:q] = nil if params[:q][:subject_cont].blank?
+    end
+
+    @q = Task.ransack(params[:q])
+    @searchs = @q.result(distinct: true)
+    # binding.pry
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -49,6 +49,6 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:subject, :content, :expired_at)
+    params.require(:task).permit(:subject, :content, :expired_at, :state)
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,11 +2,7 @@ class Task < ApplicationRecord
   validates :subject, presence: true
   validates :content, presence: true
 
-  def self.sort_expired
-    order(expired_at: :desc)
-  end
-
-  def self.latest
-    order(created_at: :desc)
-  end
+  scope :sort_expired, -> { order(expired_at: :desc) }
+  scope :latest, -> { order(created_at: :desc) }
+  scope :search_ransack, -> (parameter){ ransack(parameter) }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,8 +1,6 @@
 class Task < ApplicationRecord
   validates :subject, presence: true
   validates :content, presence: true
-  
-  enum state: { task_not_running: 0, task_running: 1, task_done: 2 }
 
   def self.sort_expired
     order(expired_at: :desc)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,7 +1,8 @@
 class Task < ApplicationRecord
   validates :subject, presence: true
   validates :content, presence: true
-  # validates :expired_at, 
+  
+  enum state: { task_not_running: 0, task_running: 1, task_done: 2 }
 
   def self.sort_expired
     order(expired_at: :desc)

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -29,9 +29,9 @@
   <% if action_name == 'edit' %>
     <div class='field'>
       <%= form.label :state %>
-      <%= form.radio_button 'state', 'task_not_running' %>未着手
-      <%= form.radio_button 'state', 'task_running' %>着手中
-      <%= form.radio_button 'state', 'task_done' %>完了
+      <%= form.radio_button 'state', '未着手' %>未着手
+      <%= form.radio_button 'state', '着手中' %>着手中
+      <%= form.radio_button 'state', '完了' %>完了
     </div>
   <% end %>
 

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -23,8 +23,17 @@
 
   <div class='field'>
     <%= form.label :expired_at %>
-    <%= form.datetime_select :expired_at %>
+    <%= form.datetime_select :expired_at, :include_blank => true %>
   </div>
+
+  <% if action_name == 'edit' %>
+    <div class='field'>
+      <%= form.label :state %>
+      <%= form.radio_button 'state', 'task_not_running' %>未着手
+      <%= form.radio_button 'state', 'task_running' %>着手中
+      <%= form.radio_button 'state', 'task_done' %>完了
+    </div>
+  <% end %>
 
   <div class='actions'>
     <%= form.submit %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -7,12 +7,14 @@
     <th>Subject</th>
     <th>Content</th>
     <th>Expired</th>
+    <th>State</th>
   </tr>
   <% @tasks.each do |task| %>
     <tr> 
       <td><%= task.subject %></td>
       <td><%= task.content %></td>
       <td><%= task.expired_at %></td>
+      <td><%= task.state %></td>
       <td><%= link_to '詳細', task_path(task.id) %></td>
       <td><%= link_to '編集', edit_task_path(task.id) %></td>
       <td><%= link_to '削除', task_path(task.id), method: :delete, data: { confirm: '本当に削除しますか？'} %></td>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -7,7 +7,7 @@
   <%= f.label :subject %>
   <%= f.search_field :subject_cont %>
   <%= f.label :state %>
-  <%= f.select :state_cont, ['指定無し','未着手','着手中','完了'] %>
+  <%= f.select :state_eq, ['指定無し','未着手','着手中','完了'] %>
   <%= f.submit 'Search' %>
 <% end %>
 

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -2,25 +2,60 @@
 
 <h1>Task一覧ページ</h1>
 
-<table border='1'>
-  <tr>
-    <th>Subject</th>
-    <th>Content</th>
-    <th>Expired</th>
-    <th>State</th>
-  </tr>
-  <% @tasks.each do |task| %>
-    <tr> 
-      <td><%= task.subject %></td>
-      <td><%= task.content %></td>
-      <td><%= task.expired_at %></td>
-      <td><%= task.state %></td>
-      <td><%= link_to '詳細', task_path(task.id) %></td>
-      <td><%= link_to '編集', edit_task_path(task.id) %></td>
-      <td><%= link_to '削除', task_path(task.id), method: :delete, data: { confirm: '本当に削除しますか？'} %></td>
-    </tr>
+<!-- (1)Subjectだけ入力 (2)Stateだけ入力 (3)どちらも入力 -->
+<%= search_form_for @q do |f| %>
+  <%= f.label :subject %>
+  <%= f.search_field :subject_cont %>
+  <%= f.label :state %>
+  <%= f.select :state_cont, ['指定無し','未着手','着手中','完了'] %>
+  <%= f.submit 'Search' %>
+<% end %>
+
+<% unless params[:q].nil? %>
+  <h3>検索結果【<%= @searchs.count %>件ヒットしました】</h3>
+  <% if @searchs.count > 0 %>
+    <table border='1'>
+      <tr>
+        <th>Subject</th>
+        <th>Content</th>
+        <th>Expired</th>
+        <th>State</th>
+      </tr>
+      <% @searchs.each do |search| %>
+        <tr>
+          <td><%= search.subject %></td>
+          <td><%= search.content %></td>
+          <td><%= search.expired_at %></td>
+          <td><%= search.state %></td>
+          <td><%= link_to '詳細', task_path(search.id) %></td>
+          <td><%= link_to '編集', edit_task_path(search.id) %></td>
+          <td><%= link_to '削除', task_path(search.id), method: :delete, data: { confirm: '本当に削除しますか？'} %></td>
+        </tr>
+      <% end %>
+    </table>
   <% end %>
-</table>
+<% else %>
+  <h3>タスクALL</h3>
+  <table border='1'>
+    <tr>
+      <th>Subject</th>
+      <th>Content</th>
+      <th>Expired</th>
+      <th>State</th>
+    </tr>
+    <% @tasks.each do |task| %>
+      <tr> 
+        <td><%= task.subject %></td>
+        <td><%= task.content %></td>
+        <td><%= task.expired_at %></td>
+        <td><%= task.state %></td>
+        <td><%= link_to '詳細', task_path(task.id) %></td>
+        <td><%= link_to '編集', edit_task_path(task.id) %></td>
+        <td><%= link_to '削除', task_path(task.id), method: :delete, data: { confirm: '本当に削除しますか？'} %></td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>
 
 <%= link_to 'タスクを登録する', new_task_path %> |
 <%= link_to 'タスクを登録順に並び替える', tasks_path %> |

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -16,5 +16,10 @@
   <%= @task.expired_at %>
 </p>
 
+<p>
+  <strong>State:</strong>
+  <%= @task.state %>
+</p>
+
 <%= link_to '一覧',root_path %> |
 <%= link_to '編集',edit_task_path(@task.id)%>

--- a/db/migrate/20190621070426_add_column_to_task.rb
+++ b/db/migrate/20190621070426_add_column_to_task.rb
@@ -1,0 +1,6 @@
+class AddColumnToTask < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :state, :integer, null: false, default: 0
+    add_index :tasks, :state
+  end
+end

--- a/db/migrate/20190621070426_add_column_to_task.rb
+++ b/db/migrate/20190621070426_add_column_to_task.rb
@@ -1,6 +1,6 @@
 class AddColumnToTask < ActiveRecord::Migration[5.2]
   def change
-    add_column :tasks, :state, :integer, null: false, default: 0
+    add_column :tasks, :state, :string, null: false, default: '未着手'
     add_index :tasks, :state
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_19_050807) do
+ActiveRecord::Schema.define(version: 2019_06_21_070426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 2019_06_19_050807) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "expired_at", default: "2019-06-19 16:13:20", null: false
+    t.integer "state", default: 0, null: false
+    t.index ["state"], name: "index_tasks_on_state"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 2019_06_21_070426) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "expired_at", default: "2019-06-19 16:13:20", null: false
-    t.integer "state", default: 0, null: false
+    t.string "state", default: "未着手", null: false
     t.index ["state"], name: "index_tasks_on_state"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,37 @@
+7000.times do |n|
+  subject = Faker::Beer.brand
+  content = Faker::Beer.name
+  expired_at = Faker::Time.between(DateTime.now , DateTime.now + 2)
+  # state = ['未着手','着手中','完了'].sample
+  state = '未着手'
+  Task.create!(
+              subject: subject,
+              content: content,
+              expired_at: expired_at,
+              state: state,
+              )
+end
+
+2000.times do |n|
+  subject = Faker::Beer.brand
+  content = Faker::Beer.name
+  expired_at = Faker::Time.between(DateTime.now , DateTime.now + 2)
+  # state = ['未着手','着手中','完了'].sample
+  state = '着手中'
+  Task.create!(
+              subject: subject,
+              content: content,
+              expired_at: expired_at,
+              state: state,
+              )
+end
+
 1000.times do |n|
   subject = Faker::Beer.brand
   content = Faker::Beer.name
   expired_at = Faker::Time.between(DateTime.now , DateTime.now + 2)
-  state = ['未着手','着手中','完了'].sample
+  # state = ['未着手','着手中','完了'].sample
+  state = '完了'
   Task.create!(
               subject: subject,
               content: content,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,12 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+1000.times do |n|
+  subject = Faker::Beer.brand
+  content = Faker::Beer.name
+  expired_at = Faker::Time.between(DateTime.now , DateTime.now + 2)
+  state = ['未着手','着手中','完了'].sample
+  Task.create!(
+              subject: subject,
+              content: content,
+              expired_at: expired_at,
+              state: state,
+              )
+end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+# save_and_open_page
 
 RSpec.feature 'タスク管理システム', type: :feature do
 
@@ -22,7 +23,6 @@ RSpec.feature 'タスク管理システム', type: :feature do
     click_button '登録する'
     expect(page).to have_content 'タスクの件名を入力する'
     expect(page).to have_content 'タスクの内容を入力する'
-
   end
 
   scenario 'タスク詳細のテスト' do
@@ -51,7 +51,6 @@ RSpec.feature 'タスク管理システム', type: :feature do
 
   scenario 'タスクが作成日時の降順に並んでいるかのテスト' do
     visit tasks_path
-    # save_and_open_page
     trs = page.all('tr')
     # テーブル最初の行には、'Subject'と'Content'が入っているため、最初のレコードが入るのは2行目から
     expect(trs[1]).to have_content 'test_task_02'
@@ -74,11 +73,50 @@ RSpec.feature 'タスク管理システム', type: :feature do
 
     click_link '一覧'
     click_link 'タスクを終了期限順に並び替える'
-    
+
     trs = page.all('tr')
     # テーブル最初の行には、'Subject'と'Content'が入っているため、最初のレコードが入るのは2行目から
     expect(trs[1]).to have_content '終了期限テスト編集2022年'
     expect(trs[2]).to have_content '終了期限テスト新規2021年'
+  end
+
+  scenario 'タスクのSubjectを検索するテスト' do
+    visit tasks_path
+    fill_in 'q_subject_cont', with: '01'
+    click_button 'Search'
+    expect(page).to have_content 'test_task_01'
+    expect(page).to have_no_content 'test_task_02'
+  end
+
+  scenario 'タスクのStateを検索するテスト' do
+    visit tasks_path
+    all('tr')[1].click_link '編集'
+    choose 'task_state_完了'
+    click_button '更新する'
+    click_link '一覧'
+    select '完了', from: 'q_state_cont'
+    click_button 'Search'
+    expect(page).to have_content 'test_task_02'
+    expect(page).to have_no_content 'test_task_01'
+  end
+
+  scenario 'タスクのSubjectとStateをAND検索するテスト' do
+    visit tasks_path
+    all('tr')[1].click_link '編集'
+    choose 'task_state_着手中'
+    click_button '更新する'
+    click_link '一覧'
+    all('tr')[2].click_link '編集'
+    choose 'task_state_着手中'
+    click_button '更新する'
+    click_link '一覧'
+
+    fill_in 'q_subject_cont', with: '01'
+    select '着手中', from: 'q_state_cont'
+    click_button 'Search'
+
+    expect(page).to have_content 'test_task_01'
+    expect(page).to have_no_content 'test_task_02'
   end
 
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -94,7 +94,7 @@ RSpec.feature 'タスク管理システム', type: :feature do
     choose 'task_state_完了'
     click_button '更新する'
     click_link '一覧'
-    select '完了', from: 'q_state_cont'
+    select '完了', from: 'q_state_eq'
     click_button 'Search'
     expect(page).to have_content 'test_task_02'
     expect(page).to have_no_content 'test_task_01'
@@ -112,7 +112,7 @@ RSpec.feature 'タスク管理システム', type: :feature do
     click_link '一覧'
 
     fill_in 'q_subject_cont', with: '01'
-    select '着手中', from: 'q_state_cont'
+    select '着手中', from: 'q_state_eq'
     click_button 'Search'
 
     expect(page).to have_content 'test_task_01'

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -75,4 +75,14 @@ RSpec.describe Task, type: :model do
     task = task.result(distinct: true)
     expect(task.empty?).to eq false
   end
+
+  it 'stateの値がnilでも、defaltの値が入るため、NotNull制約違反にならない' do
+    task = Task.new(subject: '失敗テスト', content: '失敗テスト', state: nil)
+    expect(task).to be_valid
+  end
+
+  it 'expired_atの値がnilでも、defaltの値が入るため、NotNull制約違反にならない' do
+    task = Task.new(subject: '失敗テスト', content: '失敗テスト', expired_at: nil)
+    expect(task).to be_valid
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -25,4 +25,54 @@ RSpec.describe Task, type: :model do
     task = Task.new(subject: '成功テスト', content: '成功テスト')
     expect(task).to be_valid
   end
+
+  it 'State"完了"で検索されない' do
+    Task.create(subject: '失敗テスト', content: '失敗テスト', state: '未着手')
+    task = Task.ransack("subject_cont"=>"", "state_eq"=>"完了")
+    task = task.result(distinct: true)
+    expect(task.empty?).to eq true
+  end
+
+  it 'State"完了"で検索される' do
+    Task.create(subject: '成功テスト', content: '成功テスト', state: '完了')
+    task = Task.ransack("subject_cont"=>"", "state_eq"=>"完了")
+    task = task.result(distinct: true)
+    expect(task.empty?).to eq false
+  end
+
+  it 'Subject"成功"で検索されない' do
+    Task.create(subject: '失敗テスト', content: '失敗テスト')
+    task = Task.ransack("subject_cont"=>"成功")
+    task = task.result(distinct: true)
+    expect(task.empty?).to eq true
+  end
+
+  it 'Subject"成功"で検索される' do
+    Task.create(subject: '成功テスト', content: '成功テスト')
+    task = Task.ransack("subject_cont"=>"成功")
+    task = task.result(distinct: true)
+    expect(task.empty?).to eq false
+  end
+
+  it 'Subject"成功"且つState"完了"で検索されない_Subjectが誤り' do
+    Task.create(subject: '失敗テスト', content: '失敗テスト', state: '完了')
+    task = Task.ransack("subject_cont"=>"成功", "state_eq"=>"完了")
+    task = task.result(distinct: true)
+    expect(task.empty?).to eq true
+
+  end
+
+  it 'Subject"成功"且つState"完了"で検索されない_Stateが誤り' do
+    Task.create(subject: '成功テスト', content: '成功テスト', state: '未着手')
+    task = Task.ransack("subject_cont"=>"", "state_eq"=>"完了")
+    task = task.result(distinct: true)
+    expect(task.empty?).to eq true
+  end
+
+  it 'Subject"成功"且つState"完了"で検索される' do
+    Task.create(subject: '成功テスト', content: '成功テスト', state: '完了')
+    task = Task.ransack("subject_cont"=>"", "state_eq"=>"完了")
+    task = task.result(distinct: true)
+    expect(task.empty?).to eq false
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Task, type: :model do
 
   it 'Subject"成功"且つState"完了"で検索されない_Subjectが誤り' do
     Task.create(subject: '失敗テスト', content: '失敗テスト', state: '完了')
-    task = Task.ransack("subject_cont"=>"成功", "state_eq"=>"完了")
+    task = Task.search_ransack("subject_cont"=>"成功", "state_eq"=>"完了")
     task = task.result(distinct: true)
     expect(task.empty?).to eq true
 
@@ -64,14 +64,14 @@ RSpec.describe Task, type: :model do
 
   it 'Subject"成功"且つState"完了"で検索されない_Stateが誤り' do
     Task.create(subject: '成功テスト', content: '成功テスト', state: '未着手')
-    task = Task.ransack("subject_cont"=>"", "state_eq"=>"完了")
+    task = Task.search_ransack("subject_cont"=>"", "state_eq"=>"完了")
     task = task.result(distinct: true)
     expect(task.empty?).to eq true
   end
 
   it 'Subject"成功"且つState"完了"で検索される' do
     Task.create(subject: '成功テスト', content: '成功テスト', state: '完了')
-    task = Task.ransack("subject_cont"=>"", "state_eq"=>"完了")
+    task = Task.search_ransack("subject_cont"=>"", "state_eq"=>"完了")
     task = task.result(distinct: true)
     expect(task.empty?).to eq false
   end


### PR DESCRIPTION
#20 
◆6/24(mon)
- [x] modelテストにて今回追加したscopeのテストがされていなかったため修正
　・ransackメソッドを使用している箇所を、scope(search_ransack)を使用するよう変更した。

◆6/23(sun)
- [x] show/indexに検索フォームと検索結果の表示処理追加。Ransack使用
- [x] tasksテーブルにstateカラムを追加。indexも付与。
- [x] 検索使用可否の変化を画像としてUP(DIVER課題提出の方に掲載）
- [x] seedデータ10000件用意。当初ステータスは`配列["未着手", "着手中", "完了].sample'`でランダムに入れていたが、検索結果が元データよりあまり絞りこめないと、IndexScanがされないため、1000件・2000件・7000件に振り分けて固定作成した。
- [x] explainメソッドにて確認済
- [x] ロジックをscopeに移した
- [x] model / feature specテストを行った。

```rb
”完了”で検索
[1] pry(#<TasksController>)> @q.result(distinct: true).explain
  Task Load (3.8ms)  SELECT DISTINCT "tasks".* FROM "tasks" WHERE "tasks"."state" = '完了'
  ↳ (pry):1
=> EXPLAIN for: SELECT DISTINCT "tasks".* FROM "tasks" WHERE "tasks"."state" = '完了'
                                          QUERY PLAN
-----------------------------------------------------------------------------------------------
 Unique  (cost=4.31..4.33 rows=1 width=71)
   ->  Sort  (cost=4.31..4.32 rows=1 width=71)
         Sort Key: id, subject, content, created_at, updated_at, expired_at
         ->  Index Scan using index_tasks_on_state on tasks  (cost=0.29..4.30 rows=1 width=71)
               Index Cond: ((state)::text = '完了'::text)
(5 rows)

”着手中”で検索
[1] pry(#<TasksController>)> @q.result(distinct: true).explain
  Task Load (9.3ms)  SELECT DISTINCT "tasks".* FROM "tasks" WHERE "tasks"."state" = '着手中'
  ↳ (pry):2
=> EXPLAIN for: SELECT DISTINCT "tasks".* FROM "tasks" WHERE "tasks"."state" = '着手中'
                                  QUERY PLAN
------------------------------------------------------------------------------
 HashAggregate  (cost=305.00..325.00 rows=2000 width=70)
   Group Key: id, subject, content, created_at, updated_at, expired_at, state
   ->  Seq Scan on tasks  (cost=0.00..270.00 rows=2000 width=70)
         Filter: ((state)::text = '着手中'::text)
(4 rows)

”未着手”で検索
[1] pry(#<TasksController>)> @q.result(distinct: true).explain
  Task Load (21.2ms)  SELECT DISTINCT "tasks".* FROM "tasks" WHERE "tasks"."state" = '未着手'
  ↳ (pry):3
=> EXPLAIN for: SELECT DISTINCT "tasks".* FROM "tasks" WHERE "tasks"."state" = '未着手'
                                  QUERY PLAN
------------------------------------------------------------------------------
 HashAggregate  (cost=392.50..462.50 rows=7000 width=70)
   Group Key: id, subject, content, created_at, updated_at, expired_at, state
   ->  Seq Scan on tasks  (cost=0.00..270.00 rows=7000 width=70)
         Filter: ((state)::text = '未着手'::text)
(4 rows)
```