### PR TITLE
エラーページ（例外）作成

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -35,7 +35,6 @@ class TasksController < ApplicationController
 
   def create
     @task = Task.new(task_params)
-
     if @task.save
       redirect_to root_path, notice: '新しいタスクを作成しました'
     else

--- a/app/views/layouts/admin/error.html.erb
+++ b/app/views/layouts/admin/error.html.erb
@@ -7,7 +7,7 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <meta http-equiv="refresh" content="5;URL=./../../">
+    <meta http-equiv="refresh" content="5;URL=/tasks">
   </head>
 
   <body>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports.
-  config.consider_all_requests_local = true
+  config.consider_all_requests_local = false
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -19,11 +19,11 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = true
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/public/404.html
+++ b/public/404.html
@@ -3,65 +3,24 @@
 <head>
   <title>The page you were looking for doesn't exist (404)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta http-equiv="refresh" content="5;URL=/tasks">
   <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
+  .error{
     text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
-
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    padding-top: 15%;
   }
   </style>
 </head>
 
-<body class="rails-default-error-page">
-  <!-- This file lives in public/404.html -->
-  <div class="dialog">
-    <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
-    </div>
-    <p>If you are the application owner check the logs for more information.</p>
+<body>
+  <div class="error">
+    <h1>404 not found</h1>
+    <h2>お探しのページが見つかりませんでした。</h2>
+    <p>
+      申し訳ありません。お探しのページが見つかりませんでした。<br>
+      5秒後にタスク一覧ページに戻ります
+    </p>
+    <a href="/tasks">タスク一覧ページに戻る</a>
   </div>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -4,63 +4,22 @@
   <title>We're sorry, but something went wrong (500)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
+  .error{
     text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
-
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    padding-top: 15%;
   }
   </style>
 </head>
 
-<body class="rails-default-error-page">
-  <!-- This file lives in public/500.html -->
-  <div class="dialog">
-    <div>
-      <h1>We're sorry, but something went wrong.</h1>
+<body>
+    <div class="error">
+      <h1>500 Internal Server Error</h1>
+      <h2>アクセスしようとしたページは表示できませんでした。</h2>
+      <p>
+        技術的な問題が発生したことにより、リクエストは処理されませんでした。<br>
+        大変申し訳ございませんが、お時間をおいて再度お試し下さい。
+      </p>
+      <a href="/tasks">タスク一覧ページに戻る</a>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
+  </body>
 </html>

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -2,4 +2,8 @@ FactoryBot.define do
   factory :admin do
     user_id { User.first.id }
   end
+
+  factory :second_admin, class: Admin do
+    user_id { User.last.id }
+  end
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -2,24 +2,28 @@ FactoryBot.define do
   factory :task do
     subject { 'test_task_01' }
     content { 'testtesttest' }
+    expired_at { Time.current }
     user_id { User.first.id }
   end
 
   factory :second_task, class: Task do
     subject { 'test_task_02' }
     content { 'samplesample' }
+    expired_at { Time.current }
     user_id { User.first.id }
   end
 
   factory :third_task, class: Task do
     subject { 'test_task_03' }
     content { 'hogehogehoge' }
+    expired_at { Time.current }
     user_id { User.first.id }
   end
 
   factory :fourth_task, class: Task do
     subject { 'test_task_04' }
     content { 'piyopiyopiyo' }
+    expired_at { Time.current }
     user_id { User.last.id }
   end
 end

--- a/spec/features/error.spec.rb
+++ b/spec/features/error.spec.rb
@@ -3,93 +3,34 @@ require 'rails_helper'
 RSpec.feature 'タスク管理システム(error)', type: :feature do
 
   background do
-    FactoryBot.create(:user)
-    FactoryBot.create(:admin)
     page.driver.browser.authorize('hoge', 'piyo')
     visit root_path
+  end
+
+  scenario '404ページを表示するテスト' do
+    visit '/tasks/404test'
+    expect(page).to have_content '404 not found'
+    expect(page.status_code).to eq 404
+  end
+  
+  scenario '500ページを表示するテスト' do
+    allow_any_instance_of(TasksController).to receive(:index).and_throw(Exception)
+    FactoryBot.create(:user)
     fill_in 'session_email', with: 'hoge@example.com'
     fill_in 'session_password', with: 'password'
     fill_in 'session_password_confirmation', with: 'password'
     click_button 'ログイン'
-    click_link 'Admin'
+    expect(page).to have_content '500 Internal Server Error'
+    expect(page.status_code).to equal(500)
   end
 
-  scenario '管理権限が無いユーザーが管理画面に遷移できない事を確認するテスト' do
-    FactoryBot.create(:second_user)
-    click_link 'Logout'
-    fill_in 'session_email', with: 'piyo@example.com'
-    fill_in 'session_password', with: 'piyopiyo'
-    fill_in 'session_password_confirmation', with: 'piyopiyo'
+  scenario 'admin/errorページを表示するテスト' do
+    FactoryBot.create(:user)
+    fill_in 'session_email', with: 'hoge@example.com'
+    fill_in 'session_password', with: 'password'
+    fill_in 'session_password_confirmation', with: 'password'
     click_button 'ログイン'
-    expect(page).not_to have_content 'Admin'
-  end
-
-  scenario '管理権限が有るユーザーが管理画面に遷移できる事を確認するテスト＆ユーザー一覧表示テスト' do
-    click_link 'Admin'
-    expect(page).to have_content '管理画面'
-    expect(page).to have_content 'hoge'
-    expect(page).to have_content 'hoge@example.com'
-  end
-
-  scenario 'ユーザー新規作成テスト' do
-    click_link 'ユーザーを新規登録する'
-    fill_in 'user_name', with: 'tanaka'
-    fill_in 'user_email', with: 'tarou@example.com'
-    fill_in 'user_password', with: 'password'
-    fill_in 'user_password_confirmation', with: 'password'
-    click_button 'アカウント登録する'
-    expect(page).to have_content 'アカウント作成しました'
-    expect(page).to have_content 'tanaka'
-    expect(page).to have_content 'tarou@example.com'
-  end
-
-  scenario 'ユーザー詳細のテスト' do
-    all('tr')[1].click_link '詳細'
-    expect(page).to have_content 'hoge@example.com'
-  end
-
-  scenario 'ユーザー編集のテスト' do
-    all('tr')[1].click_link '編集'
-    fill_in 'user_name', with: 'sasaki'
-    fill_in 'user_email', with: 'kensuke@nifty.com'
-    fill_in 'user_password', with: 'editedit'
-    fill_in 'user_password_confirmation', with: 'editedit'
-    click_button 'アカウント更新する'
-    expect(page).to have_content 'sasaki'
-    expect(page).to have_content 'kensuke@nifty.com'
-  end
-
-  scenario 'ユーザー削除のテスト' do
-    FactoryBot.create(:second_user)
-    click_link 'Admin'
-    save_and_open_page
-    # ログインしていないユーザーを削除
-    all('tr')[2].click_link '削除'
-    expect(page).not_to have_content 'piyo'
-    expect(page).not_to have_content 'piyo@example.com'
-    expect(page).to have_content 'ユーザーを削除しました'
-    # ログインしているユーザーを削除
-    all('tr')[1].click_link '削除'
-    expect(page).to have_content 'ログイン画面'
-  end
-
-  scenario 'ユーザー一覧にユーザー毎のタスク数表示されているかテスト' do
-    FactoryBot.create(:second_user)
-    FactoryBot.create(:task)
-    FactoryBot.create(:second_task)
-    FactoryBot.create(:third_task)
-    FactoryBot.create(:fourth_task)
-    click_link 'Admin'
-    # テーブルには数値を入れている項目が複数あるため、tdを取得
-    tds = page.all('td')
-    expect(tds[7]).to have_content '3'
-    expect(tds[14]).to have_content '1'
-  end
-
-  scenario 'ユーザーが作成したタスク一覧が詳細画面に表示されているかテスト' do
-    FactoryBot.create(:task)
-    all('tr')[1].click_link '詳細'
-    expect(page).to have_content 'test_task_01'
-    expect(page).to have_content 'testtesttest'
+    visit admin_users_path
+    expect(page).to have_content '管理者権限のないユーザーからアクセスがありました。'
   end
 end

--- a/spec/features/error.spec.rb
+++ b/spec/features/error.spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'タスク管理システム(admin)', type: :feature do
+RSpec.feature 'タスク管理システム(error)', type: :feature do
 
   background do
     FactoryBot.create(:user)
@@ -62,14 +62,12 @@ RSpec.feature 'タスク管理システム(admin)', type: :feature do
   scenario 'ユーザー削除のテスト' do
     FactoryBot.create(:second_user)
     click_link 'Admin'
+    save_and_open_page
     # ログインしていないユーザーを削除
     all('tr')[2].click_link '削除'
     expect(page).not_to have_content 'piyo'
     expect(page).not_to have_content 'piyo@example.com'
     expect(page).to have_content 'ユーザーを削除しました'
-    FactoryBot.create(:second_user)
-    FactoryBot.create(:second_admin)
-    click_link 'Admin'
     # ログインしているユーザーを削除
     all('tr')[1].click_link '削除'
     expect(page).to have_content 'ログイン画面'
@@ -93,11 +91,5 @@ RSpec.feature 'タスク管理システム(admin)', type: :feature do
     all('tr')[1].click_link '詳細'
     expect(page).to have_content 'test_task_01'
     expect(page).to have_content 'testtesttest'
-  end
-
-  scenario '管理者権限を持つユーザーが１人しかいない場合は、管理者権限を持つユーザーを削除することが出来ないテスト' do
-    click_link 'Admin'
-    all('tr')[1].click_link '削除'
-    expect(page).to have_content '管理者権限を持つユーザーを0人にすることは出来ません'
   end
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -180,7 +180,7 @@ RSpec.feature 'タスク管理システム(task)', type: :feature do
   end
 
   scenario 'タスク一覧のページネーションテスト(kaminari)' do
-    Task.create!(subject: "成功テスト", content: "成功テスト", user_id: User.first.id)
+    Task.create!(subject: "成功テスト", content: "成功テスト", expired_at: Time.current, user_id: User.first.id)
     10.times do
       FactoryBot.create(:task)
       FactoryBot.create(:second_task)
@@ -201,7 +201,6 @@ RSpec.feature 'タスク管理システム(task)', type: :feature do
     click_button 'Search'
     expect(page).not_to have_content 'test_task_04'
     expect(page).not_to have_content 'piyopiyopiyo'
-    save_and_open_page
   end
 
 end

--- a/spec/features/user.spec.rb
+++ b/spec/features/user.spec.rb
@@ -24,9 +24,8 @@ RSpec.feature 'タスク管理システム(user/session)', type: :feature do
     fill_in 'session_password', with: 'password'
     fill_in 'session_password_confirmation', with: 'password'
     click_button 'ログイン'
-    # save_and_open_page
+    save_and_open_page
     expect(page).to have_content 'ログインしました'
-    expect(page).to have_content 'hoge@example.com'
     click_link 'Logout'
     expect(page).to have_content 'ログアウトしました'
   end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -6,60 +6,60 @@ RSpec.describe Task, type: :model do
   end
 
   it 'subjectの値がnilならNotNull制約違反になる' do
-    task = Task.new(subject: nil, content: '失敗テスト', user_id: User.first.id)
+    task = Task.new(subject: nil, content: '失敗テスト', expired_at: Time.current, user_id: User.first.id)
     expect(task).not_to be_valid
   end
 
   it 'contentの値がnilならNotNull制約違反になる' do
-    task = Task.new(subject: '失敗テスト', content: nil, user_id: User.first.id)
+    task = Task.new(subject: '失敗テスト', content: nil, expired_at: Time.current, user_id: User.first.id)
     expect(task).not_to be_valid
   end
 
   it 'subjectが空ならバリデーションが通らない' do
-    task = Task.new(subject:'', content: '失敗テスト', user_id: User.first.id)
+    task = Task.new(subject: '', content: '失敗テスト', expired_at: Time.current, user_id: User.first.id)
     expect(task).not_to be_valid
   end
 
   it 'contentが空ならバリデーションが通らない' do
-    task = Task.new(subject:'失敗テスト', content: '', user_id: User.first.id)
+    task = Task.new(subject:'失敗テスト', content: '', expired_at: Time.current, user_id: User.first.id)
     expect(task).not_to be_valid
   end
 
   it 'subjectとcontentに内容が記載されていればバリデーションが通る' do
-    task = Task.new(subject: '成功テスト', content: '成功テスト', user_id: User.first.id)
+    task = Task.new(subject: '成功テスト', content: '成功テスト', expired_at: Time.current, user_id: User.first.id)
     expect(task).to be_valid
   end
 
   it 'State"完了"で検索されない' do
-    Task.create(subject: '失敗テスト', content: '失敗テスト', state: '未着手', user_id: User.first.id)
+    Task.create(subject: '失敗テスト', content: '失敗テスト', expired_at: Time.current, state: '未着手', user_id: User.first.id)
     task = Task.search_ransack("subject_cont"=>"", "state_eq"=>"完了")
     task = task.result(distinct: true)
     expect(task.empty?).to eq true
   end
 
   it 'State"完了"で検索される' do
-    Task.create(subject: '成功テスト', content: '成功テスト', state: '完了', user_id: User.first.id)
+    Task.create(subject: '成功テスト', content: '成功テスト', expired_at: Time.current, state: '完了', user_id: User.first.id)
     task = Task.search_ransack("subject_cont"=>"", "state_eq"=>"完了")
     task = task.result(distinct: true)
     expect(task.empty?).to eq false
   end
 
   it 'Subject"成功"で検索されない' do
-    Task.create(subject: '失敗テスト', content: '失敗テスト', user_id: User.first.id)
+    Task.create(subject: '失敗テスト', content: '失敗テスト', expired_at: Time.current, user_id: User.first.id)
     task = Task.search_ransack("subject_cont"=>"成功")
     task = task.result(distinct: true)
     expect(task.empty?).to eq true
   end
 
   it 'Subject"成功"で検索される' do
-    Task.create(subject: '成功テスト', content: '成功テスト', user_id: User.first.id)
+    Task.create(subject: '成功テスト', content: '成功テスト', expired_at: Time.current, user_id: User.first.id)
     task = Task.search_ransack("subject_cont"=>"成功")
     task = task.result(distinct: true)
     expect(task.empty?).to eq false
   end
 
   it 'Subject"成功"且つState"完了"で検索されない_Subjectが誤り' do
-    Task.create(subject: '失敗テスト', content: '失敗テスト', state: '完了', user_id: User.first.id)
+    Task.create(subject: '失敗テスト', content: '失敗テスト', expired_at: Time.current, state: '完了', user_id: User.first.id)
     task = Task.search_ransack("subject_cont"=>"成功", "state_eq"=>"完了")
     task = task.result(distinct: true)
     expect(task.empty?).to eq true
@@ -67,31 +67,26 @@ RSpec.describe Task, type: :model do
   end
 
   it 'Subject"成功"且つState"完了"で検索されない_Stateが誤り' do
-    Task.create(subject: '成功テスト', content: '成功テスト', state: '未着手', user_id: User.first.id)
+    Task.create(subject: '成功テスト', content: '成功テスト', expired_at: Time.current, state: '未着手', user_id: User.first.id)
     task = Task.search_ransack("subject_cont"=>"", "state_eq"=>"完了")
     task = task.result(distinct: true)
     expect(task.empty?).to eq true
   end
 
   it 'Subject"成功"且つState"完了"で検索される' do
-    Task.create(subject: '成功テスト', content: '成功テスト', state: '完了', user_id: User.first.id)
+    Task.create(subject: '成功テスト', content: '成功テスト', expired_at: Time.current, state: '完了', user_id: User.first.id)
     task = Task.search_ransack("subject_cont"=>"", "state_eq"=>"完了")
     task = task.result(distinct: true)
     expect(task.empty?).to eq false
   end
 
   it 'stateの値がnilでも、defaltの値が入るため、NotNull制約違反にならない' do
-    task = Task.new(subject: '失敗テスト', content: '失敗テスト', state: nil, user_id: User.first.id)
-    expect(task).to be_valid
-  end
-
-  it 'expired_atの値がnilでも、defaltの値が入るため、NotNull制約違反にならない' do
-    task = Task.new(subject: '失敗テスト', content: '失敗テスト', expired_at: nil, user_id: User.first.id)
+    task = Task.new(subject: '失敗テスト', content: '失敗テスト', expired_at: Time.current, state: nil, user_id: User.first.id)
     expect(task).to be_valid
   end
 
   it 'priorityの値がnilでも、defaltの値が入るため、NotNull制約違反にならない' do
-    task = Task.new(subject: '失敗テスト', content: '失敗テスト', priority: nil, user_id: User.first.id)
+    task = Task.new(subject: '失敗テスト', content: '失敗テスト', expired_at: Time.current, priority: nil, user_id: User.first.id)
     expect(task).to be_valid
   end
 end


### PR DESCRIPTION
#34 

- [x] デフォルトで作成されていた404及び500エラーページを修正
- [x] 404 / 500 / Admin権限のないユーザがAdmin画面に遷移したときのエラーページ遷移テスト作成
- [x] 落ちていたRSpecの修正

以上です。