### PR TITLE
共通ラベルと固有ラベルのCRUD及びタスクに複数のラベル設定可能に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 
 ## テーブル表
 
-|admin  |   |user           |       |task            |        |label  |       |
-|:--    |:--|:--            |:--    |:--             |:--     |:--    |:--    |
-|id     |   |id             |       |id              |        |id     |       |
-|user_id|   |name           |string |user_id         |integer |task_id|integer|
-|       |   |email          |string |subject         |string  |name   |string |
+|admin  |   |user           |       |task            |        |labeling|       |label  |       |
+|:--    |:--|:--            |:--    |:--             |:--     |:--     |:--    |:--    |       |
+|id     |   |id             |       |id              |        |id      |       |id     |       |
+|user_id|   |name           |string |user_id         |integer |task_id |integer|name   |string |
+|       |   |email          |string |subject         |string  |label_id|integer|
 |       |   |password_digest|string |content         |string  |
 |       |   |               |       |priority        |string  |
 |       |   |               |       |status          |string  |

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 
 ## テーブル表
 
-|admin  |   |user           |       |task            |        |labeling|       |label  |       |
-|:--    |:--|:--            |:--    |:--             |:--     |:--     |:--    |:--    |       |
-|id     |   |id             |       |id              |        |id      |       |id     |       |
-|user_id|   |name           |string |user_id         |integer |task_id |integer|name   |string |
-|       |   |email          |string |subject         |string  |label_id|integer|
+|admin  |   |user           |       |task            |        |labeling|       |label  |       |user_labeling|       |user_label|   |
+|:--    |:--|:--            |:--    |:--             |:--     |:--     |:--    |:--    |:--    |:--          |:--    |:--       |:--|
+|id     |   |id             |       |id              |        |id      |       |id     |       |id           |       |id        |   |
+|user_id|   |name           |string |user_id         |integer |task_id |integer|name   |string |task_id      |integer|name      |   |
+|       |   |email          |string |subject         |string  |label_id|integer|       |integer|label_id     |integer|user_id   |   |
 |       |   |password_digest|string |content         |string  |
 |       |   |               |       |priority        |string  |
 |       |   |               |       |status          |string  |

--- a/app/assets/javascripts/admin/labels.coffee
+++ b/app/assets/javascripts/admin/labels.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/admin/labels.scss
+++ b/app/assets/stylesheets/admin/labels.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin/labels controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/admin/labels_controller.rb
+++ b/app/controllers/admin/labels_controller.rb
@@ -1,9 +1,10 @@
 class Admin::LabelsController < ApplicationController
   # TODO: admin/user_controllerも:require_adminメソッドがあるので、共通化出来ないか調べる→concernsフォルダ内に作成する？
   before_action :require_admin
+  before_action :set_admin_label, only: [:edit, :update, :destroy]
 
   def index
-    @labels = Label.all
+    @labels = Label.latest
   end
 
   def new
@@ -19,12 +20,15 @@ class Admin::LabelsController < ApplicationController
     end
   end
 
-  def edit
-
-  end
+  def edit; end
 
   def update
-
+    if @label.update(label_params)
+      redirect_to admin_labels_path, notice: "ID#{@label.id}番のラベルを編集しました"
+    else
+      flash.now[:danger] = "ID#{@label.id}番のユーザーの編集に失敗しました"
+      render 'edit'
+    end
   end
 
   def destroy
@@ -37,9 +41,14 @@ class Admin::LabelsController < ApplicationController
     params.require(:label).permit(:name)
   end
 
+  def set_admin_label
+    @label = Label.find(params[:id])
+  end
+
   def require_admin
     if logged_in?
       unless Admin.find_by(user_id: current_user.id)
+        # TODO: 直接URLを指定すれば飛べてしまう。
         flash[:error] = 'このセクションにアクセス出来るのは、管理者権限のあるユーザーのみです'
         render :layout => 'admin/error', action: 'error'
       end

--- a/app/controllers/admin/labels_controller.rb
+++ b/app/controllers/admin/labels_controller.rb
@@ -7,11 +7,16 @@ class Admin::LabelsController < ApplicationController
   end
 
   def new
-
+    @label = Label.new
   end
 
   def create
-
+    @label = Label.new(label_params)
+    if @label.save
+      redirect_to admin_labels_path, notice: 'ラベルを作成しました'
+    else
+      render 'new'
+    end
   end
 
   def edit
@@ -27,6 +32,10 @@ class Admin::LabelsController < ApplicationController
   end
 
   private
+
+  def label_params
+    params.require(:label).permit(:name)
+  end
 
   def require_admin
     if logged_in?

--- a/app/controllers/admin/labels_controller.rb
+++ b/app/controllers/admin/labels_controller.rb
@@ -32,7 +32,8 @@ class Admin::LabelsController < ApplicationController
   end
 
   def destroy
-
+    @label.destroy
+    redirect_to admin_labels_path, notice: "ID#{@label.id}番のラベルを削除しました"
   end
 
   private

--- a/app/controllers/admin/labels_controller.rb
+++ b/app/controllers/admin/labels_controller.rb
@@ -1,0 +1,42 @@
+class Admin::LabelsController < ApplicationController
+  # TODO: admin/user_controllerも:require_adminメソッドがあるので、共通化出来ないか調べる→concernsフォルダ内に作成する？
+  before_action :require_admin
+
+  def index
+    @labels = Label.all
+  end
+
+  def new
+
+  end
+
+  def create
+
+  end
+
+  def edit
+
+  end
+
+  def update
+
+  end
+
+  def destroy
+
+  end
+
+  private
+
+  def require_admin
+    if logged_in?
+      unless Admin.find_by(user_id: current_user.id)
+        flash[:error] = 'このセクションにアクセス出来るのは、管理者権限のあるユーザーのみです'
+        render :layout => 'admin/error', action: 'error'
+      end
+    else
+      flash[:error] = 'ログインしていたアカウントが見つかりません'
+      redirect_to root_path
+    end
+  end
+end

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -1,0 +1,55 @@
+class LabelsController < ApplicationController
+  # TODO: 他のControllerも:require_loginメソッドがあるので、共通化出来ないか調べる→concernsフォルダ内に作成する？
+  before_action :require_login, only: [:new, :create]
+  before_action :set_user_label, only: [:edit, :update, :destroy]
+
+  def index
+    @user_labels = UserLabel.latest
+  end
+
+  def new
+    @user_label = UserLabel.new
+  end
+
+  def create
+    @user_label = UserLabel.new(user_label_params)
+    if @user_label.save
+      redirect_to labels_path, notice: 'ラベルを作成しました'
+    else
+      render 'new'
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @user_label.update(user_label_params)
+      redirect_to labels_path, notice: "ID#{@user_label.id}番のラベルを編集しました"
+    else
+      flash.now[:danger] = "ID#{@user_label.id}番のユーザーの編集に失敗しました"
+      render 'edit'
+    end
+  end
+
+  def destroy
+    @user_label.destroy
+    redirect_to labels_path, notice: "ID#{@user_label.id}番のラベルを削除しました"
+  end
+
+  private
+
+  def user_label_params
+    params.require(:user_label).permit(:name, :user_id)
+  end
+
+  def set_user_label
+    @user_label = UserLabel.find(params[:id])
+  end
+
+  def require_login
+    unless logged_in?
+      flash[:error] = 'このセクションにアクセスするにはログインして下さい'
+      redirect_to tasks_path
+    end
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,29 +4,15 @@ class TasksController < ApplicationController
 
   def index
     @tasks = params[:sort_key].present? ? Task.sorted_by(params[:sort_key], params[:page]) : Task.latest(params[:page])
-    unless params[:q].nil? || params[:q][:s].present?
-      params[:q][:user_id_eq] =
-        if params[:q][:user_id_eq] == '全てのタスク'
-          nil
-        elsif params[:q][:user_id_eq] == "#{current_user.name}のタスク"
-          current_user.id
-        end
-
-      params[:q][:state_eq] = nil if params[:q][:state_eq] == '指定無し'
-      params[:q][:subject_cont] = nil if params[:q][:subject_cont].blank?
-      params[:q] = nil if params[:q][:state_eq].nil? && params[:q][:user_id_eq].nil? && params[:q][:subject_cont].nil?
-    end
 
     # index画面にて表のNameをSortする機能を実装するにはUserテーブルの操作が必要
     # params[:q][:s] == 'name ask' || params[:q][:s] == 'name desk'
     # 要件には無いが、使えない状態はよくないので、後ほど実装方法考える。
 
-    @q = User.ransack(params[:q])
     @q = Task.search_ransack(params[:q])
     # @q.resultをモデルに移行したいが、上手くいかない。余裕があれば考える。
     @searchs = @q.result(distinct: true).page(params[:page])
     @search_count = @q.result(distinct: true).count
-
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -34,6 +34,7 @@ class TasksController < ApplicationController
   end
 
   def create
+    binding.pry
     @task = Task.new(task_params)
     if @task.save
       redirect_to root_path, notice: '新しいタスクを作成しました'

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,16 +3,17 @@ class TasksController < ApplicationController
   before_action :require_login
 
   def index
-    @tasks = params[:sort_key].present? ? Task.sorted_by(params[:sort_key], params[:page]) : Task.latest(params[:page])
-
-    # index画面にて表のNameをSortする機能を実装するにはUserテーブルの操作が必要
+    # TODO: index画面にて表のNameをSortする機能を実装するにはUserテーブルの操作が必要
     # params[:q][:s] == 'name ask' || params[:q][:s] == 'name desk'
     # 要件には無いが、使えない状態はよくないので、後ほど実装方法考える。
-
     @q = Task.search_ransack(params[:q])
-    # @q.resultをモデルに移行したいが、上手くいかない。余裕があれば考える。
-    @searchs = @q.result(distinct: true).page(params[:page])
-    @search_count = @q.result(distinct: true).count
+    if params[:q].nil?
+      @tasks = params[:sort_key].present? ? Task.sorted_by(params[:sort_key], params[:page]) : Task.latest(params[:page])
+    else
+      # TODO: @q.resultをモデルに移行したいが、上手くいかない。余裕があれば考える。
+      @tasks = @q.result(distinct: true).page(params[:page])
+      @search_count = @q.result(distinct: true).count
+    end
   end
 
   def new
@@ -21,6 +22,7 @@ class TasksController < ApplicationController
 
   def create
     @task = Task.new(task_params)
+    binding.pry
     if @task.save
       redirect_to root_path, notice: '新しいタスクを作成しました'
     else
@@ -52,7 +54,7 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:subject, :content, :expired_at, :state, :priority, :user_id, label_ids: [])
+    params.require(:task).permit(:subject, :content, :expired_at, :state, :priority, :user_id, label_ids: [], user_label_ids: [])
   end
 
   def require_login

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -22,7 +22,6 @@ class TasksController < ApplicationController
 
   def create
     @task = Task.new(task_params)
-    binding.pry
     if @task.save
       redirect_to root_path, notice: '新しいタスクを作成しました'
     else

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -34,7 +34,6 @@ class TasksController < ApplicationController
   end
 
   def create
-    binding.pry
     @task = Task.new(task_params)
     if @task.save
       redirect_to root_path, notice: '新しいタスクを作成しました'
@@ -67,7 +66,7 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:subject, :content, :expired_at, :state, :priority, :user_id)
+    params.require(:task).permit(:subject, :content, :expired_at, :state, :priority, :user_id, label_ids: [])
   end
 
   def require_login

--- a/app/helpers/admin/labels_helper.rb
+++ b/app/helpers/admin/labels_helper.rb
@@ -1,0 +1,2 @@
+module Admin::LabelsHelper
+end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,0 +1,3 @@
+class Label < ApplicationRecord
+  has_many :labelings, dependent: :destroy
+end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,6 +1,7 @@
 class Label < ApplicationRecord
   has_many :labelings, dependent: :destroy
 
+  # TODO: 同じ処理をuser_label.rbでも行っている。共通化する
   validates :name, presence: true, length: { in: 1..20 }
   scope :latest, -> { order(created_at: :asc) }
 end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,3 +1,5 @@
 class Label < ApplicationRecord
   has_many :labelings, dependent: :destroy
+
+  validates :name, presence: true, length: { in: 1..20 }
 end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,5 +1,6 @@
 class Label < ApplicationRecord
   has_many :labelings, dependent: :destroy
+
   validates :name, presence: true, length: { in: 1..20 }
   scope :latest, -> { order(created_at: :asc) }
 end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,5 +1,5 @@
 class Label < ApplicationRecord
   has_many :labelings, dependent: :destroy
-
   validates :name, presence: true, length: { in: 1..20 }
+  scope :latest, -> { order(created_at: :asc) }
 end

--- a/app/models/labeling.rb
+++ b/app/models/labeling.rb
@@ -1,0 +1,4 @@
+class Labeling < ApplicationRecord
+  belongs_to :task
+  belongs_to :label
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,7 +1,7 @@
 class Task < ApplicationRecord
   belongs_to :user
   has_many :labelings, dependent: :destroy
-  has_many :labeling_labels, through: :labelings, source: :label
+  has_many :labels, through: :labelings
 
   validates :subject, presence: true
   validates :content, presence: true

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,7 @@
 class Task < ApplicationRecord
   belongs_to :user
+  has_many :labelings, dependent: :destroy
+  has_many :labeling_labels, through: :labelings, source: :label
 
   validates :subject, presence: true
   validates :content, presence: true

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,6 +2,8 @@ class Task < ApplicationRecord
   belongs_to :user
   has_many :labelings, dependent: :destroy
   has_many :labels, through: :labelings
+  has_many :user_labelings, dependent: :destroy
+  has_many :user_labels, through: :user_labelings
 
   validates :subject, presence: true
   validates :content, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_one :admin, dependent: :destroy
   has_many :tasks, dependent: :destroy
+  has_many :user_labels, dependent: :destroy
   accepts_nested_attributes_for :admin, allow_destroy: true
 
   has_secure_password

--- a/app/models/user_label.rb
+++ b/app/models/user_label.rb
@@ -1,0 +1,8 @@
+class UserLabel < ApplicationRecord
+  belongs_to :user
+  has_many :user_labelings, dependent: :destroy
+
+  # TODO: 同じ処理をlabel.rbでも行っている。共通化する
+  validates :name, presence: true, length: { in: 1..20 }
+  scope :latest, -> { order(created_at: :asc) }
+end

--- a/app/models/user_labeling.rb
+++ b/app/models/user_labeling.rb
@@ -1,0 +1,4 @@
+class UserLabeling < ApplicationRecord
+  belongs_to :task
+  belongs_to :user_label
+end

--- a/app/views/admin/labels/edit.html.erb
+++ b/app/views/admin/labels/edit.html.erb
@@ -1,14 +1,15 @@
+
 <div class='row field'>
   <div class='col-md-12'>
-    <h2>管理画面【ラベル新規登録画面】</h2>
+    <h2>管理画面【ラベル編集画面】</h2>
   </div>
 </div>
 
 <div class='row field'>
   <div class='col-md-12'>
     <% if @label.errors.any? %>
-      <div id='error_explanation' class='alert alert-danger'>
-        <h2>このラベルは保存出来ません【<%= pluralize(@label.errors.count, 'error') %>】</h2>
+      <div id='error_explanation' class='alert alert alert-danger'>
+        <h2>このラベルを保存出来ません【<%= pluralize(@label.errors.count, 'error') %>】</h2>
         <ul>
           <% @label.errors.full_messages.each do |message| %>
             <li><%= message %></li>
@@ -21,12 +22,12 @@
 
 <div class= 'row field'>
   <div class='col-md-12'>
-    <%= form_with(model: @label, url: admin_labels_path, method: :post, local: true) do |label| %>
+    <%= form_with(model: @label, url: admin_label_path(@label.id), method: :patch, local: true) do |label| %>
       <table>
         <tr><th><%= label.label :name %></th><td><%= label.text_field :name %></td></tr>
       </table>
-      <%= label.submit 'ラベル登録する', class: 'btn btn-primary btn-sm' %>
-      <%= link_to 'ラベル一覧画面', admin_labels_path, class: 'btn btn-success btn-sm'%>
+      <%= label.submit 'ラベル更新する', class: 'btn btn-primary btn-sm' %>
+      <%= link_to 'ラベル一覧', admin_labels_path, class: 'btn btn-success btn-sm' %>
       <%= link_to 'ユーザー一覧', admin_users_path, class: 'btn btn-secondary btn-sm' %>
     <% end %>
   </div>

--- a/app/views/admin/labels/index.html.erb
+++ b/app/views/admin/labels/index.html.erb
@@ -1,0 +1,35 @@
+<div class='row field'>
+  <div class='col-md-12'>
+    <h2>管理画面【ラベル一覧画面】</h2>
+  </div>
+</div>
+
+<div class='row field'>
+  <div class='col-md-12 field'>
+    <%= link_to 'ラベルを新規登録する', new_admin_label_path, class: 'btn btn-success btn-sm' %>
+    <%= link_to 'タスク一覧画面', admin_users_path, class: 'btn btn-primary btn-sm' %>
+  </div>
+</div>
+
+<div class='row field'>
+  <div class='col-md-12'>
+    <table border=1>
+      <tr>
+        <th>id</th>
+        <td>name</td>
+        <td>タスク数</td>
+      </tr>
+
+      <% @labels.each do |label| %>
+        <tr>
+          <th><%= label.id %></th>
+          <td><%= label.name %></td>
+          <td></td>
+          <!-- <td><%#= label.tasks.count %></td> -->
+          <td><%= link_to '編集', edit_admin_label_path(label.id), class: 'btn btn-warning btn-sm' %></td>
+          <td><%= link_to '削除', admin_label_path(label.id), class: 'btn btn-danger btn-sm', method: :delete, data: { confirm: '本当に削除しますか？' } %></td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+</div>

--- a/app/views/admin/labels/index.html.erb
+++ b/app/views/admin/labels/index.html.erb
@@ -7,7 +7,7 @@
 <div class='row field'>
   <div class='col-md-12 field'>
     <%= link_to 'ラベルを新規登録する', new_admin_label_path, class: 'btn btn-success btn-sm' %>
-    <%= link_to 'タスク一覧画面', admin_users_path, class: 'btn btn-primary btn-sm' %>
+    <%= link_to 'ユーザ一覧画面', admin_users_path, class: 'btn btn-primary btn-sm' %>
   </div>
 </div>
 

--- a/app/views/admin/labels/new.html.erb
+++ b/app/views/admin/labels/new.html.erb
@@ -1,0 +1,32 @@
+<div class='row field'>
+  <div class='col-md-12'>
+    <h2>管理画面【ラベル新規登録画面】</h2>
+  </div>
+</div>
+
+<div class='row field'>
+  <div class='col-md-12'>
+    <% if @label.errors.any? %>
+      <div id='error_explanation' class='alert alert-danger'>
+        <h2>このラベルは保存出来ません【<%= pluralize(@label.errors.count, 'error') %>】</h2>
+        <ul>
+          <% @label.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class= 'row field'>
+  <div class='col-md-12'>
+    <%= form_with(model: @label, url: admin_labels_path, method: :post, local: true) do |label| %>
+      <table>
+        <tr><th><%= label.label :name %></th><td><%= label.text_field :name %></td></tr>
+      </table>
+      <%= label.submit 'ラベル登録する', class: 'btn btn-primary btn-sm' %>
+      <%= link_to 'ラベル一覧画面', admin_labels_path, class: 'btn btn-success btn-sm'%>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -5,8 +5,9 @@
 </div>
 
 <div class='row field'>
-  <div class='col-md-12'>
-    <%= link_to 'ユーザーを新規登録する', new_admin_user_path , class: 'btn btn-success btn-sm field'%>
+  <div class='col-md-12 field'>
+    <%= link_to 'ユーザーを新規登録する', new_admin_user_path, class: 'btn btn-success btn-sm'%>
+    <%= link_to 'ラベル一覧画面', admin_labels_path, class: 'btn btn-primary btn-sm' %>
   </div>
 </div>
 
@@ -31,7 +32,7 @@
           <td><%= user.tasks.count %></td>
           <td><%= link_to '詳細', admin_user_path(user.id), class: 'btn btn-info btn-sm' %></td>
           <td><%= link_to '編集', edit_admin_user_path(user.id), class: 'btn btn-warning btn-sm' %></td>
-          <td><%= link_to '削除', admin_user_path(user.id), class: 'btn btn-danger btn-sm',method: :delete, data: { confirm: '本当に削除しますか？' } %></td>
+          <td><%= link_to '削除', admin_user_path(user.id), class: 'btn btn-danger btn-sm', method: :delete, data: { confirm: '本当に削除しますか？' } %></td>
         </tr>
       <% end %>
     </table>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -7,7 +7,7 @@
 <div class='row field'>
   <div class='col-md-12'>
     <% if @user.errors.any? %>
-      <div id='error_explanation' class='alert alert alert-danger'>
+      <div id='error_explanation' class='alert alert-danger'>
         <h2>このユーザーを保存出来ません【<%= pluralize(@user.errors.count, 'error') %>】</h2>
         <ul>
           <% @user.errors.full_messages.each do |message| %>

--- a/app/views/labels/edit.html.erb
+++ b/app/views/labels/edit.html.erb
@@ -1,17 +1,17 @@
 
 <div class='row field'>
   <div class='col-md-12'>
-    <h2>管理画面【ラベル編集画面】</h2>
+    <h2>ラベル編集画面</h2>
   </div>
 </div>
 
 <div class='row field'>
   <div class='col-md-12'>
-    <% if @label.errors.any? %>
+    <% if @user_label.errors.any? %>
       <div id='error_explanation' class='alert alert alert-danger'>
-        <h2>このラベルを保存出来ません【<%= pluralize(@label.errors.count, 'error') %>】</h2>
+        <h2>このラベルを保存出来ません【<%= pluralize(@user_label.errors.count, 'error') %>】</h2>
         <ul>
-          <% @label.errors.full_messages.each do |message| %>
+          <% @user_label.errors.full_messages.each do |message| %>
             <li><%= message %></li>
           <% end %>
         </ul>
@@ -22,13 +22,12 @@
 
 <div class= 'row field'>
   <div class='col-md-12'>
-    <%= form_with(model: @label, url: admin_label_path(@label.id), method: :patch, local: true) do |label| %>
+    <%= form_with(model: @user_label, url: label_path(@user_label.id), method: :patch, local: true) do |label| %>
       <table>
         <tr><th><%= label.label :name %></th><td><%= label.text_field :name %></td></tr>
       </table>
       <%= label.submit 'ラベル更新する', class: 'btn btn-primary btn-sm' %>
-      <%= link_to 'ラベル一覧', admin_labels_path, class: 'btn btn-success btn-sm' %>
-      <%= link_to 'ユーザー一覧', admin_users_path, class: 'btn btn-secondary btn-sm' %>
+      <%= link_to 'ラベル一覧', labels_path, class: 'btn btn-success btn-sm' %>
     <% end %>
   </div>
 </div>

--- a/app/views/labels/edit.html.erb
+++ b/app/views/labels/edit.html.erb
@@ -1,0 +1,34 @@
+
+<div class='row field'>
+  <div class='col-md-12'>
+    <h2>管理画面【ラベル編集画面】</h2>
+  </div>
+</div>
+
+<div class='row field'>
+  <div class='col-md-12'>
+    <% if @label.errors.any? %>
+      <div id='error_explanation' class='alert alert alert-danger'>
+        <h2>このラベルを保存出来ません【<%= pluralize(@label.errors.count, 'error') %>】</h2>
+        <ul>
+          <% @label.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class= 'row field'>
+  <div class='col-md-12'>
+    <%= form_with(model: @label, url: admin_label_path(@label.id), method: :patch, local: true) do |label| %>
+      <table>
+        <tr><th><%= label.label :name %></th><td><%= label.text_field :name %></td></tr>
+      </table>
+      <%= label.submit 'ラベル更新する', class: 'btn btn-primary btn-sm' %>
+      <%= link_to 'ラベル一覧', admin_labels_path, class: 'btn btn-success btn-sm' %>
+      <%= link_to 'ユーザー一覧', admin_users_path, class: 'btn btn-secondary btn-sm' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/labels/index.html.erb
+++ b/app/views/labels/index.html.erb
@@ -1,0 +1,35 @@
+<div class='row field'>
+  <div class='col-md-12'>
+    <h2>管理画面【ラベル一覧画面】</h2>
+  </div>
+</div>
+
+<div class='row field'>
+  <div class='col-md-12 field'>
+    <%= link_to 'ラベルを新規登録する', new_admin_label_path, class: 'btn btn-success btn-sm' %>
+    <%= link_to 'タスク一覧画面', admin_users_path, class: 'btn btn-primary btn-sm' %>
+  </div>
+</div>
+
+<div class='row field'>
+  <div class='col-md-12'>
+    <table border=1>
+      <tr>
+        <th>id</th>
+        <td>name</td>
+        <td>タスク数</td>
+      </tr>
+
+      <% @labels.each do |label| %>
+        <tr>
+          <th><%= label.id %></th>
+          <td><%= label.name %></td>
+          <td></td>
+          <!-- <td><%#= label.tasks.count %></td> -->
+          <td><%= link_to '編集', edit_admin_label_path(label.id), class: 'btn btn-warning btn-sm' %></td>
+          <td><%= link_to '削除', admin_label_path(label.id), class: 'btn btn-danger btn-sm', method: :delete, data: { confirm: '本当に削除しますか？' } %></td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+</div>

--- a/app/views/labels/index.html.erb
+++ b/app/views/labels/index.html.erb
@@ -20,7 +20,7 @@
         <td>タスク数</td>
       </tr>
 
-      <% @user_labels.each do |label| %>
+      <% @user_labels.where(user_id: current_user.id).each do |label| %>
         <tr>
           <th><%= label.id %></th>
           <td><%= label.name %></td>

--- a/app/views/labels/index.html.erb
+++ b/app/views/labels/index.html.erb
@@ -1,13 +1,13 @@
 <div class='row field'>
   <div class='col-md-12'>
-    <h2>管理画面【ラベル一覧画面】</h2>
+    <h2><%= current_user.name %>の作成したラベル一覧画面</h2>
   </div>
 </div>
 
 <div class='row field'>
   <div class='col-md-12 field'>
-    <%= link_to 'ラベルを新規登録する', new_admin_label_path, class: 'btn btn-success btn-sm' %>
-    <%= link_to 'タスク一覧画面', admin_users_path, class: 'btn btn-primary btn-sm' %>
+    <%= link_to 'ラベルを新規登録する', new_label_path, class: 'btn btn-success btn-sm' %>
+    <%= link_to 'タスク一覧画面', tasks_path, class: 'btn btn-primary btn-sm' %>
   </div>
 </div>
 
@@ -20,14 +20,14 @@
         <td>タスク数</td>
       </tr>
 
-      <% @labels.each do |label| %>
+      <% @user_labels.each do |label| %>
         <tr>
           <th><%= label.id %></th>
           <td><%= label.name %></td>
           <td></td>
           <!-- <td><%#= label.tasks.count %></td> -->
-          <td><%= link_to '編集', edit_admin_label_path(label.id), class: 'btn btn-warning btn-sm' %></td>
-          <td><%= link_to '削除', admin_label_path(label.id), class: 'btn btn-danger btn-sm', method: :delete, data: { confirm: '本当に削除しますか？' } %></td>
+          <td><%= link_to '編集', edit_label_path(label.id), class: 'btn btn-warning btn-sm' %></td>
+          <td><%= link_to '削除', label_path(label.id), class: 'btn btn-danger btn-sm', method: :delete, data: { confirm: '本当に削除しますか？' } %></td>
         </tr>
       <% end %>
     </table>

--- a/app/views/labels/new.html.erb
+++ b/app/views/labels/new.html.erb
@@ -1,0 +1,33 @@
+<div class='row field'>
+  <div class='col-md-12'>
+    <h2>管理画面【ラベル新規登録画面】</h2>
+  </div>
+</div>
+
+<div class='row field'>
+  <div class='col-md-12'>
+    <% if @label.errors.any? %>
+      <div id='error_explanation' class='alert alert-danger'>
+        <h2>このラベルは保存出来ません【<%= pluralize(@label.errors.count, 'error') %>】</h2>
+        <ul>
+          <% @label.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class= 'row field'>
+  <div class='col-md-12'>
+    <%= form_with(model: @label, url: admin_labels_path, method: :post, local: true) do |label| %>
+      <table>
+        <tr><th><%= label.label :name %></th><td><%= label.text_field :name %></td></tr>
+      </table>
+      <%= label.submit 'ラベル登録する', class: 'btn btn-primary btn-sm' %>
+      <%= link_to 'ラベル一覧画面', admin_labels_path, class: 'btn btn-success btn-sm'%>
+      <%= link_to 'ユーザー一覧', admin_users_path, class: 'btn btn-secondary btn-sm' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/labels/new.html.erb
+++ b/app/views/labels/new.html.erb
@@ -1,16 +1,16 @@
 <div class='row field'>
   <div class='col-md-12'>
-    <h2>管理画面【ラベル新規登録画面】</h2>
+    <h2>ラベル新規登録画面</h2>
   </div>
 </div>
 
 <div class='row field'>
   <div class='col-md-12'>
-    <% if @label.errors.any? %>
+    <% if @user_label.errors.any? %>
       <div id='error_explanation' class='alert alert-danger'>
-        <h2>このラベルは保存出来ません【<%= pluralize(@label.errors.count, 'error') %>】</h2>
+        <h2>このラベルは保存出来ません【<%= pluralize(@user_label.errors.count, 'error') %>】</h2>
         <ul>
-          <% @label.errors.full_messages.each do |message| %>
+          <% @user_label.errors.full_messages.each do |message| %>
             <li><%= message %></li>
           <% end %>
         </ul>
@@ -21,13 +21,13 @@
 
 <div class= 'row field'>
   <div class='col-md-12'>
-    <%= form_with(model: @label, url: admin_labels_path, method: :post, local: true) do |label| %>
+    <%= form_with(model: @user_label, url: labels_path, method: :post, local: true) do |label| %>
       <table>
         <tr><th><%= label.label :name %></th><td><%= label.text_field :name %></td></tr>
       </table>
+      <%= label.hidden_field :user_id, value: current_user.id %>
       <%= label.submit 'ラベル登録する', class: 'btn btn-primary btn-sm' %>
-      <%= link_to 'ラベル一覧画面', admin_labels_path, class: 'btn btn-success btn-sm'%>
-      <%= link_to 'ユーザー一覧', admin_users_path, class: 'btn btn-secondary btn-sm' %>
+      <%= link_to 'ラベル一覧画面', labels_path, class: 'btn btn-success btn-sm'%>
     <% end %>
   </div>
 </div>

--- a/app/views/layouts/admin/labels.html.erb
+++ b/app/views/layouts/admin/labels.html.erb
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Admin - TaskManagementSystem</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+  </head>
+
+  <body>
+
+    <div class='container'>
+      <header class='admin_backcolor'>
+        <div class='row'>
+
+          <div class='col-md-8'>
+              <h1>タスク管理システム</h1>
+          </div>
+
+          <% if logged_in? %>
+
+            <% if Admin.find_by(user_id: current_user.id) %>
+              <div class='col-md-1 top_menu'>
+                <%= link_to 'Admin', admin_users_path %>
+              </div>
+            <% else %>
+              <div class='col-md-1 top_menu'></div>
+            <% end %>
+
+            <div class='col-md-1 top_menu'>
+              <%= link_to 'Task', tasks_path %>
+            </div>
+            <div class='col-md-1 top_menu'>
+              <%= link_to 'Profile', user_path(current_user.id) %>
+            </div>
+            <div class='col-md-1 top_menu'>
+              <%= link_to 'Logout', session_path(current_user.id), method: :delete %>
+            </div>
+          <% else %>
+            <div class='col-md-1 top_menu'></div>
+            <div class='col-md-2 top_menu'>
+              <%= link_to 'Sign up', new_user_path %>
+            </div>
+            <div class='col-md-1 top_menu'>
+              <%= link_to 'Login', new_session_path %>
+            </div>
+          <% end %>
+
+        </div>
+
+      </header>
+
+      <div class='row'>
+        <div class='col-md-12'>
+          <% flash.each do |key, value| %>
+            <% alert_color = key == 'notice' ? 'alert-success' : 'alert-danger' %>
+            <%= content_tag(:div, value, class: "#{key} alert #{alert_color}") %>
+          <% end %>
+        </div>
+      </div>
+
+        <%= yield %>
+
+      <footer class='admin_backcolor'>
+        <div class='row'>
+          <div class='col-md-12'>
+            <p>
+              作成開始:2019/6/13
+            </p>
+          </div>
+        </div>
+      </footer>
+    </div>
+
+  </body>
+</html>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -2,7 +2,7 @@
   <div class='col-md-12'>
     <% if @task.errors.any? %>
       <div id='error_explanation' class='alert alert alert-danger'>
-        <h2><%= pluralize(@task.errors.count, 'error') %></h2> 
+        <h2><%= pluralize(@task.errors.count, 'error') %></h2>
         <ul>
           <% @task.errors.full_messages.each do |message| %>
             <li><%= message %></li>
@@ -63,11 +63,14 @@
                   <%= form.check_box :label_ids, { multiple: true, checked: @task.labels.find_by(id: label.id).present?, include_hidden: false }, label[:id] %>
                 <label class='badge badge-secondary'><%= label.name %></label>
               <% end %>
-              
-              <% UserLabel.where(user_id: current_user.id).each do |label| %>
-                  <!-- TODO: Createに失敗するとチェックボックスの中身が消えてしまう。 -->
-                  <%= form.check_box :user_label_ids, { multiple: true, checked: @task.labels.find_by(id: label.id).present?, include_hidden: false }, label[:id] %>
-                <label class='badge badge-info'><%= label.name %></label>
+
+              <!-- TODO: 動的にラベルを追加できるとなお良い -->
+              <% if @task.user_id.equal?(current_user.id) %>
+                <% UserLabel.where(user_id: current_user.id).each do |label| %>
+                    <!-- TODO: Createに失敗するとチェックボックスの中身が消えてしまう。 -->
+                    <%= form.check_box :user_label_ids, { multiple: true, checked: @task.user_labels.find_by(id: label.id).present?, include_hidden: false }, label[:id] %>
+                  <label class='badge badge-info'><%= label.name %></label>
+                <% end %>
               <% end %>
             </td>
           </tr>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -50,6 +50,17 @@
               <%= form.radio_button 'priority', :low %>low
             </td>
           </tr>
+
+           <tr class='field'>
+            <th>ラベル</th>
+            <td>
+              <!-- TODO: 現時点ではどのユーザーが作成したラベルでも全て表示されるので修正する -->
+              <% Label.all.each do |label| %>
+                <%= form.check_box :label_ids, { multiple: true, checked: label[:checked], disabled: label[:disabled], include_hidden: false }, label[:id] %>
+                <label style='background-color: aquamarine'><%= label.name %></label>
+              <% end %>
+            </td>
+          </tr>
         <% end %>
       </table>
 

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -51,13 +51,14 @@
             </td>
           </tr>
 
-           <tr class='field'>
-            <th>ラベル</th>
+          <tr class='field'>
+            <th>Label</th>
             <td>
-              <!-- TODO: 現時点ではどのユーザーが作成したラベルでも全て表示されるので修正する -->
+              <!-- TODO: 現時点ではどのユーザーが作成したラベルでも全て表示されるので修正 -->
               <% Label.all.each do |label| %>
-                <%= form.check_box :label_ids, { multiple: true, checked: label[:checked], disabled: label[:disabled], include_hidden: false }, label[:id] %>
-                <label style='background-color: aquamarine'><%= label.name %></label>
+                  <!-- TODO: Createに失敗するとチェックボックスの中身が消えてしまう。 -->
+                  <%= form.check_box :label_ids, { multiple: true, checked: @task.labels.find_by(id: label.id).present?, include_hidden: false }, label[:id] %>
+                <label class='badge badge-secondary'><%= label.name %></label>
               <% end %>
             </td>
           </tr>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -28,7 +28,11 @@
           <td><%= form.datetime_select :expired_at, { default: Time.current }, :include_blank => true%></td>
         </tr>
 
-        <%= form.hidden_field :user_id, value: @task.user_id %>
+        <% if action_name == 'new' || action_name == 'create' %>
+          <%= form.hidden_field :user_id, value: current_user.id %>
+        <% else %>
+          <%= form.hidden_field :user_id, value: @task.user_id %>
+        <% end %>
 
         <% if action_name == 'new' || action_name == 'edit' || action_name == 'create' || action_name == 'update'%>
           <tr class='field'>
@@ -54,11 +58,16 @@
           <tr class='field'>
             <th>Label</th>
             <td>
-              <!-- TODO: 現時点ではどのユーザーが作成したラベルでも全て表示されるので修正 -->
               <% Label.all.each do |label| %>
                   <!-- TODO: Createに失敗するとチェックボックスの中身が消えてしまう。 -->
                   <%= form.check_box :label_ids, { multiple: true, checked: @task.labels.find_by(id: label.id).present?, include_hidden: false }, label[:id] %>
                 <label class='badge badge-secondary'><%= label.name %></label>
+              <% end %>
+              
+              <% UserLabel.where(user_id: current_user.id).each do |label| %>
+                  <!-- TODO: Createに失敗するとチェックボックスの中身が消えてしまう。 -->
+                  <%= form.check_box :user_label_ids, { multiple: true, checked: @task.labels.find_by(id: label.id).present?, include_hidden: false }, label[:id] %>
+                <label class='badge badge-info'><%= label.name %></label>
               <% end %>
             </td>
           </tr>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -28,7 +28,7 @@
           <td><%= form.datetime_select :expired_at, { default: Time.current }, :include_blank => true%></td>
         </tr>
 
-        <%= form.hidden_field :user_id, value: current_user.id %>
+        <%= form.hidden_field :user_id, value: @task.user_id %>
 
         <% if action_name == 'new' || action_name == 'edit' || action_name == 'create' || action_name == 'update'%>
           <tr class='field'>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -65,7 +65,7 @@
               <% end %>
 
               <!-- TODO: 動的にラベルを追加できるとなお良い -->
-              <% if @task.user_id.equal?(current_user.id) %>
+              <% if action_name == 'new' || action_name == 'create' || @task.user_id.equal?(current_user.id) %>
                 <% UserLabel.where(user_id: current_user.id).each do |label| %>
                     <!-- TODO: Createに失敗するとチェックボックスの中身が消えてしまう。 -->
                     <%= form.check_box :user_label_ids, { multiple: true, checked: @task.user_labels.find_by(id: label.id).present?, include_hidden: false }, label[:id] %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -20,9 +20,15 @@
       <%= f.label :subject %>
       <%= f.search_field :subject_cont %>
       <%= f.label :state %>
-      <%= f.select :state_eq, ['指定無し','未着手','着手中','完了'] %>
+      <%= f.select :state_eq, ['未着手','着手中','完了'], include_blank: "指定無し" %>
       <%= f.label :user_id %>
-      <%= f.select :user_id_eq, ["全てのタスク", "#{current_user.name}のタスク"] %>
+      <%= f.select :user_id_eq, [["#{current_user.name}" , "#{current_user.id}"]], include_blank: "全てのタスク" %>
+
+      <% if Label.count > 0 %>
+        <%= f.label :labels_name %>
+        <%= f.select :labels_id_eq, Label.all.map {|label| [label.name, label.id]}, include_blank: "指定無し" %>
+      <% end %>
+
       <%= f.submit 'Search', class: 'btn btn-primary btn-sm' %>
     <% end %>
   </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -47,6 +47,8 @@
 
   <div class='col-md-12'>
     <%= link_to 'タスクを新規登録する', new_task_path , class: 'btn btn-success btn-sm field'%>
+    <%= link_to 'ラベル一覧画面', labels_path, class: 'btn btn-primary btn-sm' %>
+
   </div>
 
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -29,11 +29,16 @@
         <%= f.select :labels_id_eq, Label.all.map {|label| [label.name, label.id]}, include_blank: "指定無し" %>
       <% end %>
 
+      <% if UserLabel.where(user_id: current_user.id).count > 0 %>
+        <%= f.label :user_labels_name %>
+        <%= f.select :user_labels_id_eq, UserLabel.where(user_id: current_user.id).map {|label| [label.name, label.id]}, include_blank: "指定無し" %>
+      <% end %>
+
       <%= f.submit 'Search', class: 'btn btn-primary btn-sm' %>
     <% end %>
   </div>
 
-  <% paginations = params[:q].nil? ? @tasks : @searchs %>
+  <% paginations = @tasks %>
 
   <div class='col-md-12'>
     <%= page_entries_info paginations %>
@@ -44,62 +49,17 @@
     <%= link_to 'タスクを新規登録する', new_task_path , class: 'btn btn-success btn-sm field'%>
   </div>
 
-  <% unless params[:q].nil? %>
-
 </div>
+
     <div class='row field'>
       <div class='col-md-12'>
-        <h3>検索結果【<%= @search_count %>件ヒットしました】</h3>
-        <% if @searchs.count > 0 %>
-          <table border='1'>
-
-            <tr>
-              <th><%= sort_link(@q, :name) %></th>
-              <th><%= sort_link(@q, :subject) %></th>
-              <th><%= sort_link(@q, :content) %></th>
-              <th><%= sort_link(@q, :expired_at) %></th>
-              <th><%= sort_link(@q, :state) %></th>
-              <th><%= sort_link(@q, :priority) %></th>
-              <th>Label</th>
-            </tr>
-
-            <% @searchs.each do |search| %>
-              <!-- 【課題】現段階ではState毎に背景色を分けているが、ソート対象をPriorityにした場合に背景色を切り替えれればなお良い。 -->
-              <% if search.state == '未着手' %>
-                <tr class='task_not_running'>
-              <% elsif search.state == '着手中' %>
-                <tr class='task_running'>
-              <% else %>
-                <tr class='task_done'>
-              <% end %>
-                <td><%= search.user.name %></td>
-                <td><%= search.subject %></td>
-                <td><%= search.content %></td>
-                <td><%= search.expired_at %></td>
-                <td><%= search.state %></td>
-                <td><%= search.priority %></td>
-                <td>
-                  <% search.labels.each do |label| %>
-                    <span class='badge badge-secondary'><%= label.name %></span>
-                  <% end %>
-                </td>
-                <td><%= link_to '詳細', task_path(search.id), class: 'btn btn-info btn-sm' %></td>
-                <td><%= link_to '編集', edit_task_path(search.id), class: 'btn btn-warning btn-sm' %></td>
-                <td><%= link_to '削除', task_path(search.id), class: 'btn btn-danger btn-sm',method: :delete, data: { confirm: '本当に削除しますか？'} %></td>
-              </tr>
-            <% end %>
-
-          </table>
+        <% if @search_count.present? %>
+          <h3>検索結果【<%= @search_count %>件ヒットしました】</h3>
+        <% else %>
+          <h3>タスクALL</h3>
         <% end %>
-      </div>
-    </div>
 
-  <% else %>
-
-</div>
-    <div class='row field'>
-      <div class='col-md-12'>
-        <h3>タスクALL</h3>
+        <% if @tasks.count > 0 %>
         <table border='1'>
           <tr>
             <th><%= sort_link(@q, :name) %></th>
@@ -129,6 +89,12 @@
                   <% task.labels.each do |label| %>
                     <span class='badge badge-secondary'><%= label.name %></span>
                   <% end %>
+
+                  <% if task.user_id.equal?(current_user.id) %>
+                    <% task.user_labels.each do |label| %>
+                      <span class='badge badge-info'><%= label.name %></span>
+                    <% end %>
+                  <% end %>
                 </td>
                 <td><%= link_to '詳細', task_path(task.id), class: 'btn btn-info btn-sm' %></td>
                 <td><%= link_to '編集', edit_task_path(task.id), class: 'btn btn-warning btn-sm' %></td>
@@ -137,10 +103,10 @@
           <% end %>
 
         </table>
+        <% end %>
       </div>
     </div>
 
-  <% end %>
 
 <div class='row field'>
   <div class='col-md-12'>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -54,6 +54,7 @@
               <th><%= sort_link(@q, :expired_at) %></th>
               <th><%= sort_link(@q, :state) %></th>
               <th><%= sort_link(@q, :priority) %></th>
+              <th>Label</th>
             </tr>
 
             <% @searchs.each do |search| %>
@@ -71,6 +72,11 @@
                 <td><%= search.expired_at %></td>
                 <td><%= search.state %></td>
                 <td><%= search.priority %></td>
+                <td>
+                  <% search.labels.each do |label| %>
+                    <span class='badge badge-secondary'><%= label.name %></span>
+                  <% end %>
+                </td>
                 <td><%= link_to '詳細', task_path(search.id), class: 'btn btn-info btn-sm' %></td>
                 <td><%= link_to '編集', edit_task_path(search.id), class: 'btn btn-warning btn-sm' %></td>
                 <td><%= link_to '削除', task_path(search.id), class: 'btn btn-danger btn-sm',method: :delete, data: { confirm: '本当に削除しますか？'} %></td>
@@ -96,6 +102,7 @@
             <th><%= sort_link(@q, :expired_at) %></th>
             <th><%= sort_link(@q, :state) %></th>
             <th><%= sort_link(@q, :priority) %></th>
+            <th>Label</th>
           </tr>
 
           <% @tasks.each do |task| %>
@@ -112,6 +119,11 @@
                 <td><%= task.expired_at %></td>
                 <td><%= task.state %></td>
                 <td><%= task.priority %></td>
+                <td>
+                  <% task.labels.each do |label| %>
+                    <span class='badge badge-secondary'><%= label.name %></span>
+                  <% end %>
+                </td>
                 <td><%= link_to '詳細', task_path(task.id), class: 'btn btn-info btn-sm' %></td>
                 <td><%= link_to '編集', edit_task_path(task.id), class: 'btn btn-warning btn-sm' %></td>
                 <td><%= link_to '削除', task_path(task.id), class: 'btn btn-danger btn-sm',method: :delete, data: { confirm: '本当に削除しますか？'} %></td>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -9,6 +9,14 @@
       <tr><th>Expired:</th><td><%= @task.expired_at %></td></tr>
       <tr><th>State:</th><td><%= @task.state %></td></tr>
       <tr><th>Priority:</th><td><%= @task.priority %></td></tr>
+      <tr>
+        <th>Label:</th>
+        <td>
+          <% @task.labels.each do |label| %>
+            <span class='badge badge-secondary'><%= label.name %></span>
+          <% end %>
+        </td>
+      </tr>
     </table>
 
     <%= link_to '一覧', root_path, class: 'btn btn-success btn-sm ' %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -15,6 +15,10 @@
           <% @task.labels.each do |label| %>
             <span class='badge badge-secondary'><%= label.name %></span>
           <% end %>
+
+          <% @task.user_labels.each do |label| %>
+            <span class='badge badge-info'><%= label.name %></span>
+          <% end %>
         </td>
       </tr>
     </table>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,8 +4,8 @@
     <p>メールアドレス: <%= @user.email %></p>
     <p>
       作成したラベル：
-      <% @user.labels.pluck(:name).each do |label| %>
-        <span class='badge badge-secondary'><%= label %></span>
+      <% @user.user_labels.all.each do |label| %>
+        <span class='badge badge-info'><%= link_to "#{label.name}", edit_label_path(label.id) %></span>
       <% end %>
     </p>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,5 +2,11 @@
   <div class='col-md-12'>
     <h3><%= @user.name %>のページ</h3>
     <p>メールアドレス: <%= @user.email %></p>
+    <p>
+      作成したラベル：
+      <% @user.labels.pluck(:name).each do |label| %>
+        <span class='badge badge-secondary'><%= label %></span>
+      <% end %>
+    </p>
   </div>
 </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports.
-  config.consider_all_requests_local = false
+  config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
         get :error
       end
     end
+    resources :labels
   end
   resources :sessions, only:[:new, :create, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   root to: 'sessions#new'
   resources :tasks
   resources :users, only:[:new, :create, :show]
+  resources :sessions, only:[:new, :create, :destroy]
+  resources :labels
+
   namespace :admin do
     resources :users do
       collection do
@@ -13,5 +16,4 @@ Rails.application.routes.draw do
     end
     resources :labels
   end
-  resources :sessions, only:[:new, :create, :destroy]
 end

--- a/db/migrate/20190705042858_create_labels.rb
+++ b/db/migrate/20190705042858_create_labels.rb
@@ -1,0 +1,9 @@
+class CreateLabels < ActiveRecord::Migration[5.2]
+  def change
+    create_table :labels do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190705043445_create_labelings.rb
+++ b/db/migrate/20190705043445_create_labelings.rb
@@ -1,0 +1,10 @@
+class CreateLabelings < ActiveRecord::Migration[5.2]
+  def change
+    create_table :labelings do |t|
+      t.integer :task_id, null: false
+      t.integer :label_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190709065518_create_user_labels.rb
+++ b/db/migrate/20190709065518_create_user_labels.rb
@@ -1,0 +1,10 @@
+class CreateUserLabels < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_labels do |t|
+      t.string :name, null: false
+      t.references :user, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190709071030_create_user_labelings.rb
+++ b/db/migrate/20190709071030_create_user_labelings.rb
@@ -1,0 +1,10 @@
+class CreateUserLabelings < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_labelings do |t|
+      t.references :task, foreign_key: true, null: false
+      t.references :user_label, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190709072248_add_index_to_labeling_task_id_and_label_id.rb
+++ b/db/migrate/20190709072248_add_index_to_labeling_task_id_and_label_id.rb
@@ -1,0 +1,6 @@
+class AddIndexToLabelingTaskIdAndLabelId < ActiveRecord::Migration[5.2]
+  def change
+    add_index :labelings, :task_id
+    add_index :labelings, :label_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_05_043445) do
+ActiveRecord::Schema.define(version: 2019_07_09_072248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,8 @@ ActiveRecord::Schema.define(version: 2019_07_05_043445) do
     t.integer "label_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["label_id"], name: "index_labelings_on_label_id"
+    t.index ["task_id"], name: "index_labelings_on_task_id"
   end
 
   create_table "labels", force: :cascade do |t|
@@ -46,6 +48,23 @@ ActiveRecord::Schema.define(version: 2019_07_05_043445) do
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
+  create_table "user_labelings", force: :cascade do |t|
+    t.bigint "task_id", null: false
+    t.bigint "user_label_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["task_id"], name: "index_user_labelings_on_task_id"
+    t.index ["user_label_id"], name: "index_user_labelings_on_user_label_id"
+  end
+
+  create_table "user_labels", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_labels_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
@@ -57,4 +76,7 @@ ActiveRecord::Schema.define(version: 2019_07_05_043445) do
 
   add_foreign_key "admins", "users"
   add_foreign_key "tasks", "users"
+  add_foreign_key "user_labelings", "tasks"
+  add_foreign_key "user_labelings", "user_labels"
+  add_foreign_key "user_labels", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_04_020304) do
+ActiveRecord::Schema.define(version: 2019_07_05_043445) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,6 +18,19 @@ ActiveRecord::Schema.define(version: 2019_07_04_020304) do
   create_table "admins", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_admins_on_user_id"
+  end
+
+  create_table "labelings", force: :cascade do |t|
+    t.integer "task_id", null: false
+    t.integer "label_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "labels", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "tasks", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,7 @@
 1.times do |n|
   User.create!(
     name: 'admin',
-    email: 'admin@admin.admin',
+    email: Faker::Internet.email,
     password: 'password',
     password_confirmation: 'password',
     )
@@ -27,7 +27,7 @@ end
   state = ['未着手','着手中','完了'].sample
   priority = [0, 1, 2].sample
   user_id_array = []
-  (User.last.id - User.first.id + 1).times do |n| user_id_array << (n + User.first.id) end
+  User.all.each do |user| user_id_array << user.id end
   user_id = user_id_array.sample
   Task.create!(
               subject: subject,
@@ -37,6 +37,11 @@ end
               priority: priority,
               user_id: user_id,
               )
+end
+
+10.times do |n|
+  name = "test_label_#{n}"
+  Label.create!(name: name)
 end
 
 

--- a/spec/factories/create_admin_callbacks.rb
+++ b/spec/factories/create_admin_callbacks.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :create_admin_callback do
-    
-  end
-end

--- a/spec/factories/labelings.rb
+++ b/spec/factories/labelings.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :labeling do
+    task_id { 1 }
+    label_id { 1 }
+  end
+end

--- a/spec/factories/labelings.rb
+++ b/spec/factories/labelings.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :labeling do
     task_id { Task.first.id }
-    label_id { Label.last.id }
+    label_id { Label.first.id }
   end
 
   factory :second_labeling, class: Labeling do

--- a/spec/factories/labelings.rb
+++ b/spec/factories/labelings.rb
@@ -1,6 +1,11 @@
 FactoryBot.define do
   factory :labeling do
-    task_id { 1 }
-    label_id { 1 }
+    task_id { Task.first.id }
+    label_id { Label.last.id }
+  end
+
+  factory :second_labeling, class: Labeling do
+    task_id { Task.first.id }
+    label_id { Label.last.id }
   end
 end

--- a/spec/factories/labels.rb
+++ b/spec/factories/labels.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :label do
+    name { "MyString" }
+  end
+end

--- a/spec/factories/labels.rb
+++ b/spec/factories/labels.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :label do
-    name { "MyString" }
+    name { 'Ruby' }
+  end
+
+  factory :second_label, class: Label do
+    name { 'Python' }
   end
 end

--- a/spec/factories/user_labelings.rb
+++ b/spec/factories/user_labelings.rb
@@ -1,6 +1,11 @@
 FactoryBot.define do
   factory :user_labeling do
-    task { nil }
-    user_label { nil }
+    task_id { Task.first.id }
+    user_label_id { UserLabel.first.id }
+  end
+
+  factory :second_user_labeling, class: UserLabeling do
+    task_id { Task.first.id }
+    user_label_id { UserLabel.last.id }
   end
 end

--- a/spec/factories/user_labelings.rb
+++ b/spec/factories/user_labelings.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user_labeling do
+    task { nil }
+    user_label { nil }
+  end
+end

--- a/spec/factories/user_labels.rb
+++ b/spec/factories/user_labels.rb
@@ -1,5 +1,11 @@
 FactoryBot.define do
   factory :user_label do
-    user { nil }
+    name { "Vue.js" }
+    user_id { User.first.id }
+  end
+
+  factory :second_user_label, class: UserLabel do
+    name { 'React' }
+    user_id { User.first.id }
   end
 end

--- a/spec/factories/user_labels.rb
+++ b/spec/factories/user_labels.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user_label do
-    name { "Vue.js" }
+    name { 'Vue.js' }
     user_id { User.first.id }
   end
 

--- a/spec/factories/user_labels.rb
+++ b/spec/factories/user_labels.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user_label do
+    user { nil }
+  end
+end

--- a/spec/features/label.spec.rb
+++ b/spec/features/label.spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.feature 'タスク管理システム(task)', type: :feature do
+
+  background do
+    # FactoryBot.create(:user)
+    # FactoryBot.create(:task)
+    # FactoryBot.create(:second_task)
+    # FactoryBot.create(:third_task)
+    # page.driver.browser.authorize('hoge', 'piyo')
+    # visit root_path
+    # fill_in 'session_email', with: 'hoge@example.com'
+    # fill_in 'session_password', with: 'password'
+    # fill_in 'session_password_confirmation', with: 'password'
+    # click_button 'ログイン'
+  end
+
+  scenario 'タスク新規作成と編集をする時に、あるユーザが作成したラベルを他のユーザが使用することが出来ない事を確認' do
+
+  end
+
+  scenario '管理者のみ作成できるラベルを選択して、タスクを作成する' do
+
+  end
+
+  scenario '各ユーザが作成できるラベルを選択して、タスクを作成する' do
+
+  end
+
+  scenario '管理者のみ作成できるラベルと、各ユーザが作成できるラベルを両方選択して、タスクを作成する' do
+
+  end
+
+  scenario 'タスク一覧の検索に現在ログインしているユーザが作成したラベルのプルダウンが表示されている事を確認' do
+
+  end
+
+  scenario 'タスク一覧に管理者のみ作成できるラベルが表示されている事を確認' do
+
+  end
+
+  scenario 'タスク一覧に各ユーザが作成できるラベルが表示されている事を確認' do
+
+  end
+  
+  scenario '' do
+
+  end
+
+end

--- a/spec/features/label.spec.rb
+++ b/spec/features/label.spec.rb
@@ -27,6 +27,14 @@ RSpec.feature 'タスク管理システム(task)', type: :feature do
 
   end
 
+  scenario '管理者が作成できるラベルを編集する' do
+
+  end
+
+  scenario '各ユーザが作成できるラベルを編集する' do
+
+  end
+
   scenario '管理者のみ作成できるラベルと、各ユーザが作成できるラベルを両方選択して、タスクを作成する' do
 
   end

--- a/spec/features/label.spec.rb
+++ b/spec/features/label.spec.rb
@@ -24,51 +24,156 @@ RSpec.feature 'タスク管理システム(label)', type: :feature do
     click_button 'ログイン'
   end
 
-  scenario '管理者のみ作成できるラベルを選択して、タスクを作成する' do
+  scenario '管理者のみ作成できる共通ラベルを選択して、タスクを作成する' do
     click_link 'タスクを新規登録する'
-    fill_in 'task_subject', with: '共通ラベルをつけてタスクを作成する'
+    fill_in 'task_subject', with: '共有ラベルをつけてタスクを作成する'
     fill_in 'task_content', with: 'テストを成功させる'
     check 'task_label_ids_1'
     click_button '登録する'
     expect(page).to have_content '新しいタスクを作成しました'
     expect(all('tr')[1]).to have_content 'Ruby'
-    # save_and_open_page
-  end
-  
-  scenario '各ユーザが作成できるラベルを選択して、タスクを作成する' do
-    
-  end
-  
-  scenario '管理者が作成できるラベルを編集する' do
-    
-  end
-  
-  scenario '各ユーザが作成できるラベルを編集する' do
-    
-  end
-  
-  scenario '管理者のみ作成できるラベルと、各ユーザが作成できるラベルを両方選択して、タスクを作成する' do
-    
   end
 
-  scenario 'タスク新規作成と編集をする時に、あるユーザが作成したラベルを他のユーザが使用することが出来ない事を確認' do
-
+  scenario '各ユーザ固有のラベルを選択して、タスクを作成する' do
+    click_link 'タスクを新規登録する'
+    fill_in 'task_subject', with: 'ユーザ固有のラベルをつけてタスクを作成する'
+    fill_in 'task_content', with: 'テストを成功させる'
+    check 'task_user_label_ids_3'
+    check 'task_user_label_ids_4'
+    click_button '登録する'
+    expect(page).to have_content '新しいタスクを作成しました'
+    expect(all('tr')[1]).to have_content 'Vue.js'
+    expect(all('tr')[1]).to have_content 'React'
   end
 
-  scenario 'タスク一覧の検索に現在ログインしているユーザが作成したラベルのプルダウンが表示されている事を確認' do
-
+  scenario '管理者のみ作成できる共有ラベルと、各ユーザが作成できる固有ラベルを両方選択して、タスクを作成する' do
+    click_link 'タスクを新規登録する'
+    fill_in 'task_subject', with: '共通ラベルとユーザ固有のラベルをつけてタスクを作成する'
+    fill_in 'task_content', with: 'テストを成功させる'
+    check 'task_label_ids_5'
+    check 'task_label_ids_6'
+    check 'task_user_label_ids_5'
+    check 'task_user_label_ids_6'
+    click_button '登録する'
+    expect(all('tr')[1]).to have_content '共通ラベルとユーザ固有のラベルをつけてタスクを作成する'
+    expect(all('tr')[1]).to have_content 'テストを成功させる'
+    expect(all('tr')[1]).to have_content 'Ruby'
+    expect(all('tr')[1]).to have_content 'Python'
+    expect(all('tr')[1]).to have_content 'Vue.js'
+    expect(all('tr')[1]).to have_content 'React'
   end
 
-  scenario 'タスク一覧に管理者のみ作成できるラベルが表示されている事を確認' do
-
+  scenario 'タスクを編集しラベルを付け替える' do
+    expect(page).to have_content 'Ruby'
+    expect(page).to have_content 'Vue.js'
+    all('tr')[1].click_link '編集'
+    uncheck 'task_label_ids_7'
+    uncheck 'task_user_label_ids_7'
+    click_button '更新する'
+    expect(page).not_to have_content 'Ruby'
+    expect(page).not_to have_content 'Vue.js'
   end
 
-  scenario 'タスク一覧に各ユーザが作成できるラベルが表示されている事を確認' do
-
+  scenario '共有のラベルを新規作成する' do
+    visit new_admin_label_path
+    fill_in 'label_name', with: '共有ラベル'
+    click_button 'ラベル登録する'
+    expect(page).to have_content 'ラベルを作成しました'
+    expect(page).to have_content '共有ラベル'
   end
-  
-  scenario '' do
 
+  scenario '共有のラベルを編集する' do
+    visit admin_labels_path
+    all('tr')[1].click_link '編集'
+    fill_in 'label_name', with: '共有ラベル編集'
+    click_button 'ラベル更新する'
+    expect(page).to have_content 'ラベルを編集しました'
+    expect(page).to have_content '共有ラベル編集'
+  end
+
+  scenario '各ユーザ固有のラベルを作成する' do
+    visit new_label_path
+    fill_in 'user_label_name', with: '固有ラベル'
+    click_button 'ラベル登録する'
+    expect(page).to have_content 'ラベルを作成しました'
+    expect(page).to have_content '固有ラベル'
+  end
+
+  scenario '各ユーザ固有のラベルを編集する' do
+    visit labels_path
+    all('tr')[1].click_link '編集'
+    fill_in 'user_label_name', with: '固有ラベル編集'
+    click_button 'ラベル更新する'
+    expect(page).to have_content 'ラベルを編集しました'
+    expect(page).to have_content '固有ラベル編集'
+  end
+
+  scenario 'タスク一覧の検索に、共通ラベルのプルダウンが表示されている事を確認' do
+    expect(page).to have_select('q_labels_id_eq', options: ['指定無し', 'Ruby', 'Python'])
+  end
+
+  scenario 'タスク一覧の検索に、現在ログインしているユーザの固有ラベルのプルダウンが表示されている事を確認' do
+    expect(page).to have_select('q_user_labels_id_eq', options: ['指定無し', 'Vue.js', 'React'])
+  end
+
+  scenario 'タスク一覧に共有ラベルだけ表示されている事を確認' do
+    FactoryBot.create(:second_user)
+    expect(page).to have_content 'Ruby'
+    expect(page).to have_content 'Python'
+    expect(page).to have_content 'Vue.js'
+    expect(page).to have_content 'React'
+    click_link 'Logout'
+    fill_in 'session_email', with: 'piyo@example.com'
+    fill_in 'session_password', with: 'piyopiyo'
+    fill_in 'session_password_confirmation', with: 'piyopiyo'
+    click_button 'ログイン'
+    expect(page).to have_content 'Ruby'
+    expect(page).to have_content 'Python'
+    expect(page).not_to have_content 'Vue.js'
+    expect(page).not_to have_content 'React'
+  end
+
+  scenario 'タスク一覧に共通ラベルと固有ラベルが表示されている事を確認' do
+    expect(page).to have_content 'Ruby'
+    expect(page).to have_content 'Python'
+    expect(page).to have_content 'Vue.js'
+    expect(page).to have_content 'React'
+  end
+
+  scenario 'タスク新規作成時に、あるユーザが作成した固有ラベルを他のユーザが使用することが出来ない事を確認' do
+    FactoryBot.create(:second_user)
+    expect(page).to have_content 'Ruby'
+    expect(page).to have_content 'Python'
+    expect(page).to have_content 'Vue.js'
+    expect(page).to have_content 'React'
+    click_link 'Logout'
+    fill_in 'session_email', with: 'piyo@example.com'
+    fill_in 'session_password', with: 'piyopiyo'
+    fill_in 'session_password_confirmation', with: 'piyopiyo'
+    click_button 'ログイン'
+    click_link 'タスクを新規登録する'
+    expect(page).to have_content 'Ruby'
+    expect(page).to have_content 'Python'
+    expect(page).not_to have_content 'Vue.js'
+    expect(page).not_to have_content 'React'
+  end
+
+  scenario 'タスク編集時に、あるユーザが作成した固有ラベルを他のユーザが使用することが出来ない事を確認' do
+    FactoryBot.create(:second_user)
+    expect(page).to have_content 'Ruby'
+    expect(page).to have_content 'Python'
+    expect(page).to have_content 'Vue.js'
+    expect(page).to have_content 'React'
+    click_link 'Logout'
+    fill_in 'session_email', with: 'piyo@example.com'
+    fill_in 'session_password', with: 'piyopiyo'
+    fill_in 'session_password_confirmation', with: 'piyopiyo'
+    click_button 'ログイン'
+    all('tr')[1].click_link '編集'
+    expect(page).to have_content 'Ruby'
+    expect(page).to have_content 'Python'
+    expect(page).not_to have_content 'Vue.js'
+    expect(page).not_to have_content 'React'
   end
 
 end

--- a/spec/features/label.spec.rb
+++ b/spec/features/label.spec.rb
@@ -1,41 +1,57 @@
 require 'rails_helper'
 
-RSpec.feature 'タスク管理システム(task)', type: :feature do
+RSpec.feature 'タスク管理システム(label)', type: :feature do
 
   background do
-    # FactoryBot.create(:user)
-    # FactoryBot.create(:task)
+    FactoryBot.create(:user)
+    FactoryBot.create(:admin)
+    FactoryBot.create(:task)
+    FactoryBot.create(:label)
+    FactoryBot.create(:second_label)
+    FactoryBot.create(:labeling)
+    FactoryBot.create(:second_labeling)
+    FactoryBot.create(:user_label)
+    FactoryBot.create(:second_user_label)
+    FactoryBot.create(:user_labeling)
+    FactoryBot.create(:second_user_labeling)
     # FactoryBot.create(:second_task)
     # FactoryBot.create(:third_task)
-    # page.driver.browser.authorize('hoge', 'piyo')
-    # visit root_path
-    # fill_in 'session_email', with: 'hoge@example.com'
-    # fill_in 'session_password', with: 'password'
-    # fill_in 'session_password_confirmation', with: 'password'
-    # click_button 'ログイン'
-  end
-
-  scenario 'タスク新規作成と編集をする時に、あるユーザが作成したラベルを他のユーザが使用することが出来ない事を確認' do
-
+    page.driver.browser.authorize('hoge', 'piyo')
+    visit root_path
+    fill_in 'session_email', with: 'hoge@example.com'
+    fill_in 'session_password', with: 'password'
+    fill_in 'session_password_confirmation', with: 'password'
+    click_button 'ログイン'
   end
 
   scenario '管理者のみ作成できるラベルを選択して、タスクを作成する' do
-
+    click_link 'タスクを新規登録する'
+    fill_in 'task_subject', with: '共通ラベルをつけてタスクを作成する'
+    fill_in 'task_content', with: 'テストを成功させる'
+    check 'task_label_ids_1'
+    click_button '登録する'
+    expect(page).to have_content '新しいタスクを作成しました'
+    expect(all('tr')[1]).to have_content 'Ruby'
+    # save_and_open_page
   end
-
+  
   scenario '各ユーザが作成できるラベルを選択して、タスクを作成する' do
-
+    
   end
-
+  
   scenario '管理者が作成できるラベルを編集する' do
-
+    
   end
-
+  
   scenario '各ユーザが作成できるラベルを編集する' do
-
+    
+  end
+  
+  scenario '管理者のみ作成できるラベルと、各ユーザが作成できるラベルを両方選択して、タスクを作成する' do
+    
   end
 
-  scenario '管理者のみ作成できるラベルと、各ユーザが作成できるラベルを両方選択して、タスクを作成する' do
+  scenario 'タスク新規作成と編集をする時に、あるユーザが作成したラベルを他のユーザが使用することが出来ない事を確認' do
 
   end
 

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -197,7 +197,7 @@ RSpec.feature 'タスク管理システム(task)', type: :feature do
     FactoryBot.create(:second_user)
     FactoryBot.create(:fourth_task)
     visit tasks_path
-    select 'hogeのタスク', from: 'q_user_id_eq'
+    select 'hoge', from: 'q_user_id_eq'
     click_button 'Search'
     expect(page).not_to have_content 'test_task_04'
     expect(page).not_to have_content 'piyopiyopiyo'

--- a/spec/features/user.spec.rb
+++ b/spec/features/user.spec.rb
@@ -24,7 +24,6 @@ RSpec.feature 'タスク管理システム(user/session)', type: :feature do
     fill_in 'session_password', with: 'password'
     fill_in 'session_password_confirmation', with: 'password'
     click_button 'ログイン'
-    save_and_open_page
     expect(page).to have_content 'ログインしました'
     click_link 'Logout'
     expect(page).to have_content 'ログアウトしました'

--- a/spec/models/create_admin_callback_spec.rb
+++ b/spec/models/create_admin_callback_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe CreateAdminCallback, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/label_spec.rb
+++ b/spec/models/label_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe Label, type: :model do
   it 'nameの値がnilの状態で保存するとNotNull例外評価になる' do
     label = Label.new(name: nil)
-    expect { label.save }.to raise_error(ActiveRecord::NotNullViolation)
+    # expect { label.save }.to raise_error(ActiveRecord::NotNullViolation)
+    expect(label.save).to be_falsey
   end
 
   it 'Labelテーブルに正しく保存される' do

--- a/spec/models/label_spec.rb
+++ b/spec/models/label_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Label, type: :model do
+  it 'nameの値がnilの状態で保存するとNotNull例外評価になる' do
+    label = Label.new(name: nil)
+    expect { label.save }.to raise_error(ActiveRecord::NotNullViolation)
+  end
+
+  it 'Labelテーブルに正しく保存される' do
+    label = Label.new(name: '成功テスト')
+    expect(label.save).to be_truthy
+  end
+end

--- a/spec/models/labeling_spec.rb
+++ b/spec/models/labeling_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Labeling, type: :model do
+  before do
+    User.create!(name: 'test', email: 'test@example.com', password: 'password', password_confirmation: 'password')
+    Task.create!(subject: 'タスク件名', content: 'テストする', expired_at: Time.current, user_id: User.first.id)
+    Label.create!(name: 'testlabel')
+  end
+
+  it 'task_idの値nilの状態で保存するとtaskのバリデーションが通らない' do
+    labeling = Labeling.new(task_id: nil, label_id: Label.first.id)
+    expect(labeling).not_to be_valid
+  end
+
+  it 'label_idの値nilの状態で保存するとlabelのバリデーションが通らない' do
+    labeling = Labeling.new(task_id: Task.first.id, label_id: nil)
+    expect(labeling).not_to be_valid
+  end
+
+  it 'Labelingテーブルに正しく保存される' do
+    labeling = Labeling.new(task_id: Task.first.id, label_id: Label.first.id)
+    expect(labeling).to be_valid
+  end
+end

--- a/spec/models/user_label_spec.rb
+++ b/spec/models/user_label_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe UserLabel, type: :model do
+  before do
+    User.create!(name: 'test', email: 'test@example.com', password: 'password', password_confirmation: 'password')
+  end
+
+  it 'nameの値がnilの状態で保存するとNotNull例外評価になる' do
+    user_label = UserLabel.new(name: nil, user_id: User.first.id)
+    expect { user_label.save }.to raise_error(ActiveRecord::NotNullViolation)
+  end
+
+  it 'user_idの値がnilの状態で保存するとNotNull例外評価になる' do
+    user_label = UserLabel.new(name: '失敗テスト', user_id: nil)
+    expect(user_label.save).to be_falsey
+  end
+
+  it 'UserLabelテーブルに正しく保存される' do
+    user_label = UserLabel.new(name: '成功テスト', user_id: User.first.id)
+    expect(user_label.save).to be_truthy
+  end
+end

--- a/spec/models/user_label_spec.rb
+++ b/spec/models/user_label_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe UserLabel, type: :model do
 
   it 'nameの値がnilの状態で保存するとNotNull例外評価になる' do
     user_label = UserLabel.new(name: nil, user_id: User.first.id)
-    expect { user_label.save }.to raise_error(ActiveRecord::NotNullViolation)
+    # expect { user_label.save }.to raise_error(ActiveRecord::NotNullViolation)
+    expect(user_label.save).to be_falsey
   end
 
   it 'user_idの値がnilの状態で保存するとNotNull例外評価になる' do

--- a/spec/models/user_labeling_spec.rb
+++ b/spec/models/user_labeling_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe UserLabeling, type: :model do
+  before do
+    User.create!(name: 'test', email: 'test@example.com', password: 'password', password_confirmation: 'password')
+    Task.create!(subject: 'タスク件名', content: 'テストする', expired_at: Time.current, user_id: User.first.id)
+    UserLabel.create!(name: 'testlabel',user_id: User.first.id)
+  end
+
+  it 'task_idの値nilの状態で保存するとtaskのバリデーションが通らない' do
+    user_labeling = UserLabeling.new(task_id: nil, user_label_id: UserLabel.first.id)
+    expect(user_labeling).not_to be_valid
+  end
+
+  it 'label_idの値nilの状態で保存するとlabelのバリデーションが通らない' do
+    user_labeling = UserLabeling.new(task_id: Task.first.id, user_label_id: nil)
+    expect(user_labeling).not_to be_valid
+  end
+
+  it 'UserLabelingテーブルに正しく保存される' do
+    user_labeling = UserLabeling.new(task_id: Task.first.id, user_label_id: UserLabel.first.id)
+    expect(user_labeling).to be_valid
+  end
+
+end


### PR DESCRIPTION
#35

- [x] テーブルを追加した
共通ラベル：Task(1) - (n)Labeling(n) - (1)Label
固有ラベル：User(1) - (n)UserLabel
　　　　　　Task(1) - (n)UserLabeling(n) - (1)UserLabel

- [x] 管理画面に各ユーザ共通ラベルのCRUD機能作成
- [x] 通常画面に各ユーザ固有ラベルのCRUD機能作成
- [x] タスク一覧画面にて、共通ラベル及び固有ラベルでタスクを検索できるよう修正
- [x] タスク新規登録及び編集時にラベルの付け外しが出来るよう修正
- [x] FeatureSpec作成 / モデルテスト作成

以上